### PR TITLE
Fix activity names associated to BasicSample* layouts

### DIFF
--- a/espresso/BasicSample/app/src/main/res/layout/activity_show_text.xml
+++ b/espresso/BasicSample/app/src/main/res/layout/activity_show_text.xml
@@ -18,7 +18,7 @@
              xmlns:tools="http://schemas.android.com/tools"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
-             tools:context="com.example.android.testing.espresso.BasicSample.AuxActivity">
+             tools:context=".ShowTextActivity">
 
     <TextView
             android:id="@+id/show_text_view"

--- a/espresso/BasicSampleBundled/res/layout/activity_show_text.xml
+++ b/espresso/BasicSampleBundled/res/layout/activity_show_text.xml
@@ -18,7 +18,7 @@
              xmlns:tools="http://schemas.android.com/tools"
              android:layout_width="match_parent"
              android:layout_height="match_parent"
-             tools:context="com.example.android.testing.espresso.BasicSample.AuxActivity">
+             tools:context=".ShowTextActivity">
 
     <TextView
             android:id="@+id/show_text_view"


### PR DESCRIPTION
Update layouts tools.context to reflect current activity name (replace AuxActivity by ShowTextActivity).