### PR TITLE
update_uiautomator_version

### DIFF
--- a/uiautomator/BasicSample/app/build.gradle
+++ b/uiautomator/BasicSample/app/build.gradle
@@ -30,6 +30,6 @@ dependencies {
     // Testing-only dependencies
     androidTestCompile 'com.android.support.test:runner:0.2'
     // UiAutomator Testing
-    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.0.0'
+    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.0'
     androidTestCompile 'org.hamcrest:hamcrest-integration:1.1'
 }


### PR DESCRIPTION
This updates uiautomator-v18 to version 2.1.0, which at least on "Google Repository v16", it does contain the source code.

It still has the UiObject2.setText() bug on empty textboxes with KitKat and lower, but it's a step forward.