### PR TITLE
Espresso fails

### DIFF
--- a/espresso/BasicSample/build.gradle
+++ b/espresso/BasicSample/build.gradle
@@ -16,4 +16,8 @@ allprojects {
     repositories {
         jcenter()
     }
+
+configurations.all {
+    resolutionStrategy.force 'com.android.support:support-annotations:22.1.0'
+    }
 }

--- a/espresso/MultiWindowSample/build.gradle
+++ b/espresso/MultiWindowSample/build.gradle
@@ -16,4 +16,8 @@ allprojects {
     repositories {
         jcenter()
     }
+
+ configurations.all {
+    resolutionStrategy.force 'com.android.support:support-annotations:22.1.0'
+    }
 }


### PR DESCRIPTION
Without this change the ./gradlew connectedCheck fails with the following error:

Conflict with dependency 'com.android.support:support-annotations'. Resolved versions for app (22.1.0) and test app (22.0.0) differ.

