### PR TITLE
java.lang.NoClassDefFoundError when using support-v4:23.0.1

### DIFF
--- a/ui/espresso/BasicSample/app/build.gradle
+++ b/ui/espresso/BasicSample/app/build.gradle
@@ -24,12 +24,15 @@ android {
 
 dependencies {
     // App dependencies
+    compile 'com.android.support:support-v4:23.0.1'
     compile 'com.android.support:support-annotations:23.0.1'
     compile 'com.google.guava:guava:18.0'
     // Testing-only dependencies
     // Force usage of support annotations in the test app, since it is internally used by the runner module.
+    //androidTestCompile 'com.android.support:support-v4:23.0.1'
     androidTestCompile 'com.android.support:support-annotations:23.0.1'
     androidTestCompile 'com.android.support.test:runner:0.4'
     androidTestCompile 'com.android.support.test:rules:0.4'
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
+    androidTestCompile 'com.android.support.test.espresso:espresso-contrib:2.2.1'
 }

--- a/ui/espresso/BasicSample/app/src/main/java/com/example/android/testing/espresso/BasicSample/MainActivity.java
+++ b/ui/espresso/BasicSample/app/src/main/java/com/example/android/testing/espresso/BasicSample/MainActivity.java
@@ -16,7 +16,7 @@
 
 package com.example.android.testing.espresso.BasicSample;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
@@ -28,7 +28,7 @@ import android.widget.TextView;
  * clicks on one of the two buttons. The first one shows it in the same activity and the second
  * one opens another activity and displays the message.
  */
-public class MainActivity extends Activity implements View.OnClickListener {
+public class MainActivity extends FragmentActivity implements View.OnClickListener {
 
     // The TextView used to display the message inside the Activity.
     private TextView mTextView;


### PR DESCRIPTION
This PR is just to illustrate the issue I mentioned to @slinzner about the inclusion of `espresso-contrib:2.2.1` caused `NoClassDefFoundError`

actually, just use the following will cause `NoClassDefFoundError`

    androidTestCompile 'com.android.support:support-v4:23.0.1'

So maybe it's more of the issue with `support-v4` package than the `espresso-contrib` package? 

DO NOT MERGE.
