### PR TITLE
Added support to the Marshmallow new permission model

### DIFF
--- a/ui/espresso/IntentsBasicSample/app/build.gradle
+++ b/ui/espresso/IntentsBasicSample/app/build.gradle
@@ -22,6 +22,8 @@ android {
 dependencies {
     // App dependencies
     compile 'com.android.support:support-annotations:23.0.1'
+    compile 'com.android.support:support-v4:23.0.1'
+
     // Testing-only dependencies
     // Force usage of support annotations in the test app, since it is internally used by the runner module.
     androidTestCompile 'com.android.support:support-annotations:23.0.1'

--- a/ui/espresso/IntentsBasicSample/app/src/main/java/com/example/android/testing/espresso/BasicSample/DialerActivity.java
+++ b/ui/espresso/IntentsBasicSample/app/src/main/java/com/example/android/testing/espresso/BasicSample/DialerActivity.java
@@ -16,12 +16,16 @@
 
 package com.example.android.testing.espresso.BasicSample;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.Toast;
 
 /**
  * Simple Dialer Activity which shows an {@link EditText} field to enter a phone number. Upon
@@ -46,7 +50,13 @@ public class DialerActivity extends Activity {
     }
 
     public void onCall(View view) {
-        startActivity(createCallIntentFromNumber());
+        boolean hasCallPhonePermission = ContextCompat.checkSelfPermission(this,
+            Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED;
+
+        if (hasCallPhonePermission)
+            startActivity(createCallIntentFromNumber());
+        else
+            Toast.makeText(this, R.string.warning_call_phone_permission, Toast.LENGTH_SHORT).show();
     }
 
     public void onPickContact(View view) {

--- a/ui/espresso/IntentsBasicSample/app/src/main/res/values/strings.xml
+++ b/ui/espresso/IntentsBasicSample/app/src/main/res/values/strings.xml
@@ -23,4 +23,5 @@
         This activity is never opened and does not contain any real contact data for
         keeping this sample simple and focused.
     </string>
+    <string name="warning_call_phone_permission">This app requires \'call phone\' permission to run</string>
 </resources>


### PR DESCRIPTION
**Problem:**

The app was crashing because the _CALL_PHONE_ permission was missing on devices using API 23.

![crash](https://cloud.githubusercontent.com/assets/3531999/12074645/5ee6f3d8-b15f-11e5-9148-e5fcc6ab40fd.gif)

Related stacktrace:

```
01-02 14:19:09.540 13818-13818/com.example.android.testing.espresso.BasicSample E/AndroidRuntime: FATAL EXCEPTION: main
  Process: com.example.android.testing.espresso.BasicSample, PID: 13818
  java.lang.IllegalStateException: Could not execute method for android:onClick
      at android.view.View$DeclaredOnClickListener.onClick(View.java:4452)
      at android.view.View.performClick(View.java:5198)
      at android.view.View$PerformClick.run(View.java:21147)
      at android.os.Handler.handleCallback(Handler.java:739)
      at android.os.Handler.dispatchMessage(Handler.java:95)
      at android.os.Looper.loop(Looper.java:148)
      at android.app.ActivityThread.main(ActivityThread.java:5417)
      at java.lang.reflect.Method.invoke(Native Method)
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
   Caused by: java.lang.reflect.InvocationTargetException
      at java.lang.reflect.Method.invoke(Native Method)
      at android.view.View$DeclaredOnClickListener.onClick(View.java:4447)
      at android.view.View.performClick(View.java:5198) 
      at android.view.View$PerformClick.run(View.java:21147) 
      at android.os.Handler.handleCallback(Handler.java:739) 
      at android.os.Handler.dispatchMessage(Handler.java:95) 
      at android.os.Looper.loop(Looper.java:148) 
      at android.app.ActivityThread.main(ActivityThread.java:5417) 
      at java.lang.reflect.Method.invoke(Native Method) 
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 
   Caused by: java.lang.SecurityException: Permission Denial: starting Intent { act=android.intent.action.CALL dat=tel:xxxxxxx cmp=com.android.server.telecom/.components.UserCallActivity } from ProcessRecord{849900c 13818:com.example.android.testing.espresso.BasicSample/u0a58} (pid=13818, uid=10058) with revoked permission android.permission.CALL_PHONE
      at android.os.Parcel.readException(Parcel.java:1599)
      at android.os.Parcel.readException(Parcel.java:1552)
      at android.app.ActivityManagerProxy.startActivity(ActivityManagerNative.java:2658)
      at android.app.Instrumentation.execStartActivity(Instrumentation.java:1507)
      at android.app.Activity.startActivityForResult(Activity.java:3917)
      at android.app.Activity.startActivityForResult(Activity.java:3877)
      at android.app.Activity.startActivity(Activity.java:4200)
      at android.app.Activity.startActivity(Activity.java:4168)
      at com.example.android.testing.espresso.BasicSample.DialerActivity.onCall(DialerActivity.java:49)
      at java.lang.reflect.Method.invoke(Native Method) 
      at android.view.View$DeclaredOnClickListener.onClick(View.java:4447) 
      at android.view.View.performClick(View.java:5198) 
      at android.view.View$PerformClick.run(View.java:21147) 
      at android.os.Handler.handleCallback(Handler.java:739) 
      at android.os.Handler.dispatchMessage(Handler.java:95) 
      at android.os.Looper.loop(Looper.java:148) 
      at android.app.ActivityThread.main(ActivityThread.java:5417) 
      at java.lang.reflect.Method.invoke(Native Method) 
      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726) 
      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616) 
```

**Fix:**

Using the `ContextCompat` class from `com.android.support:support-v4` the user can be warmed about the issue regarding the permission.

```java
    public void onCall(View view) {
        boolean hasCallPhonePermission = ContextCompat.checkSelfPermission(this,
            Manifest.permission.CALL_PHONE) == PackageManager.PERMISSION_GRANTED;

        if (hasCallPhonePermission)
            startActivity(createCallIntentFromNumber());
        else
            Toast.makeText(this, R.string.warning_call_phone_permission, Toast.LENGTH_SHORT).show();
    }
```

![fix](https://cloud.githubusercontent.com/assets/3531999/12074656/0f0c1c8e-b160-11e5-8234-dfc436b8f415.gif)

