### PR TITLE
Fixed {@code} javadoc tag

### DIFF
--- a/unit/BasicSample/app/src/main/java/com/example/android/testing/unittesting/BasicSample/SharedPreferencesHelper.java
+++ b/unit/BasicSample/app/src/main/java/com/example/android/testing/unittesting/BasicSample/SharedPreferencesHelper.java
@@ -48,7 +48,7 @@ public class SharedPreferencesHelper {
      * {@link SharedPreferences}.
      *
      * @param sharedPreferenceEntry contains data to save to {@link SharedPreferences}.
-     * @return @{code true} if writing to {@link SharedPreferences} succeeded. @{code false}
+     * @return {@code true} if writing to {@link SharedPreferences} succeeded. {@code false}
      *         otherwise.
      */
     public boolean savePersonalInfo(SharedPreferenceEntry sharedPreferenceEntry){


### PR DESCRIPTION
Fixed 2 instances of javadoc {@code} tags (was written as @{code} )