### PR TITLE
Custom Listener always gets description == null

### DIFF
--- a/runner/AndroidJunitRunnerSample/app/src/androidTest/java/com/example/android/testing/androidjunitrunnersample/suite/MyListener.java
+++ b/runner/AndroidJunitRunnerSample/app/src/androidTest/java/com/example/android/testing/androidjunitrunnersample/suite/MyListener.java
@@ -1,0 +1,43 @@
+package com.example.android.testing.androidjunitrunnersample.suite;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+
+public class MyListener extends RunListener {
+    @Override
+    public void testRunStarted(Description description) throws Exception {
+        super.testRunStarted(description);
+    }
+
+    @Override
+    public void testRunFinished(Result result) throws Exception {
+        super.testRunFinished(result);
+    }
+
+    @Override
+    public void testStarted(Description description) throws Exception {
+        super.testStarted(description);
+    }
+
+    @Override
+    public void testFinished(Description description) throws Exception {
+        super.testFinished(description);
+    }
+
+    @Override
+    public void testFailure(Failure failure) throws Exception {
+        super.testFailure(failure);
+    }
+
+    @Override
+    public void testAssumptionFailure(Failure failure) {
+        super.testAssumptionFailure(failure);
+    }
+
+    @Override
+    public void testIgnored(Description description) throws Exception {
+        super.testIgnored(description);
+    }
+}


### PR DESCRIPTION
I am trying to get a custom listener running.

I opened the project in Android Studio and setup the listener by adding:
`
-e listener com.example.android.testing.androidjunitrunnersample.suite.MyListener
`

If I breakpoint on `super.testRunStarted(description);` I get that description is `null` when it shouldn't.

What am I doing wrong?

