### PR TITLE
Use http_archive instead of git_repository to fetch dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,20 +7,26 @@ android_sdk_repository(
     path = SDK_PATH,
 )
 
-git_repository(
+# Android Test Support
+ATS_COMMIT = "ecc3a8fc236ad89fe6511feb743d1b08be1b53c9"
+
+http_archive(
     name = "android_test_support",
-    commit = "ecc3a8fc236ad89fe6511feb743d1b08be1b53c9",
-    remote = "https://github.com/google/android-testing-support-library",
+    strip_prefix = "android-testing-support-library-%s" % ATS_COMMIT,
+    urls = ["https://github.com/google/android-testing-support-library/archive/%s.tar.gz" % ATS_COMMIT],
 )
 
 load("@android_test_support//:repo.bzl", "android_test_repositories")
 
 android_test_repositories()
 
-git_repository(
+# Google Maven Repository
+GMAVEN_COMMIT = "5e89b7cdc94d002c13576fad3b28b0ae30296e55"
+
+http_archive(
     name = "gmaven_rules",
-    commit = "5e89b7cdc94d002c13576fad3b28b0ae30296e55",
-    remote = "https://github.com/aj-michael/gmaven_rules",
+    strip_prefix = "gmaven_rules-%s" % GMAVEN_COMMIT,
+    urls = ["https://github.com/aj-michael/gmaven_rules/archive/%s.tar.gz" % GMAVEN_COMMIT],
 )
 
 load("@gmaven_rules//:gmaven.bzl", "gmaven_rules")


### PR DESCRIPTION
`http_archive` is a lot more reliable than `git_repository`, and doesn't introduce a dependency on `git`. The native `git_repository` rule is also deprecated.