### PR TITLE
Update gmaven_rules target to use gmaven_artifact

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,14 +1,15 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 java_library(
     name = "test_deps",
     visibility = ["//visibility:public"],
     exports = [
-        "@com_android_support_support_annotations_27_0_2//jar",
-        "@com_android_support_test_espresso_espresso_core_3_0_1//aar",
-        "@com_android_support_test_espresso_espresso_idling_resource_3_0_1//aar",
-        "@com_android_support_test_rules_1_0_1//aar",
-        "@com_android_support_test_runner_1_0_1//aar",
+        gmaven_artifact("com.android.support:support-annotations:jar:27.0.2"),
+        gmaven_artifact("com.android.support.test.espresso:espresso-core:aar:3.0.1"),
+        gmaven_artifact("com.android.support.test:rules:aar:1.0.1"),
+        gmaven_artifact("com.android.support.test:runner:aar:1.0.1"),
         "@com_google_guava_guava//jar",
         "@com_google_inject_guice//jar",
         "@javax_inject_javax_inject//jar",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -8,7 +8,7 @@ android_sdk_repository(
 )
 
 # Android Test Support
-ATS_COMMIT = "ecc3a8fc236ad89fe6511feb743d1b08be1b53c9"
+ATS_COMMIT = "be7fa5191b3e3eb70411357af13f011dcfb95b50"
 
 http_archive(
     name = "android_test_support",
@@ -21,7 +21,7 @@ load("@android_test_support//:repo.bzl", "android_test_repositories")
 android_test_repositories()
 
 # Google Maven Repository
-GMAVEN_COMMIT = "5e89b7cdc94d002c13576fad3b28b0ae30296e55"
+GMAVEN_COMMIT = "44d75d3e7bdfa8ff0b30ceb048b0f09bc6b72c70"
 
 http_archive(
     name = "gmaven_rules",

--- a/ui/espresso/CustomMatcherSample/BUILD.bazel
+++ b/ui/espresso/CustomMatcherSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,7 +9,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_support_annotations_27_0_2//jar",
+        gmaven_artifact("com.android.support:support-annotations:27.0.2"),
         "@com_google_guava_guava//jar",
     ],
 )

--- a/ui/espresso/DataAdapterSample/BUILD.bazel
+++ b/ui/espresso/DataAdapterSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,7 +9,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_support_annotations_27_0_2//jar",
+        gmaven_artifact("com.android.support:support-annotations:27.0.2"),
         "@com_google_guava_guava//jar",
     ],
 )

--- a/ui/espresso/IdlingResourceSample/BUILD.bazel
+++ b/ui/espresso/IdlingResourceSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,8 +9,8 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_support_annotations_27_0_2//jar",
-        "@com_android_support_test_espresso_espresso_idling_resource_3_0_1//aar",
+        gmaven_artifact("com.android.support:support-annotations:27.0.2"),
+        gmaven_artifact("com.android.support.test.espresso:espresso-idling-resource:aar:3.0.1"),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -25,6 +27,7 @@ android_library(
     srcs = glob(["app/src/androidTest/**/*.java"]),
     custom_package = "com.example.android.testing.espresso.IdlingResourceSample",
     deps = [
+        gmaven_artifact("com.android.support.test.espresso:espresso_idling_resource:aar:3.0.1"),
         ":IdlingResourceSampleLib",
         "//:test_deps",
     ],

--- a/ui/espresso/IntentsAdvancedSample/BUILD.bazel
+++ b/ui/espresso/IntentsAdvancedSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,7 +9,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_support_annotations_27_0_2//jar",
+        gmaven_artifact("com.android.support:support-annotations:27.0.2"),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -24,9 +26,9 @@ android_library(
     srcs = glob(["app/src/androidTest/**/*.java"]),
     custom_package = "com.example.android.testing.espresso.intents.AdvancedSample",
     deps = [
+        gmaven_artifact("com.android.support.test.espresso:espresso-intents:aar:3.0.1"),
         ":IntentsAdvancedSampleLib",
         "//:test_deps",
-        "@com_android_support_test_espresso_espresso_intents_3_0_1//aar",
     ],
 )
 

--- a/ui/espresso/IntentsBasicSample/BUILD.bazel
+++ b/ui/espresso/IntentsBasicSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,8 +9,8 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_support_annotations_27_0_2//jar",
-        "@com_android_support_support_compat_27_0_2//aar",
+        gmaven_artifact("com.android.support:support-annotations:27.0.2"),
+        gmaven_artifact("com.android.support:support-compat:aar:27.0.2"),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -27,7 +29,7 @@ android_library(
     deps = [
         ":IntentsBasicSampleLib",
         "//:test_deps",
-        "@com_android_support_test_espresso_espresso_intents_3_0_1//aar",
+        gmaven_artifact("com.android.support.test.espresso:espresso-intents:aar:3.0.1"),
     ],
 )
 

--- a/ui/espresso/MultiWindowSample/BUILD.bazel
+++ b/ui/espresso/MultiWindowSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,7 +9,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_support_annotations_27_0_2//jar",
+        gmaven_artifact("com.android.support:support-annotations:jar:27.0.2"),
         "@com_google_guava_guava//jar",
     ],
 )

--- a/ui/espresso/RecyclerViewSample/BUILD.bazel
+++ b/ui/espresso/RecyclerViewSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -7,8 +9,8 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        "@com_android_support_recyclerview_v7_27_0_2//aar",
-        "@com_android_support_support_annotations_27_0_2//jar",
+        gmaven_artifact("com.android.support:recyclerview_v7:aar:27.0.2"),
+        gmaven_artifact("com.android.support:support-annotations:27.0.2"),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -25,9 +27,9 @@ android_library(
     srcs = glob(["app/src/androidTest/**/*.java"]),
     custom_package = "com.example.android.testing.espresso.RecyclerViewSample",
     deps = [
+        gmaven_artifact("com.android.support.test.espresso:espresso-contrib:aar:3.0.2-alpha1"),
         ":RecyclerViewSampleLib",
         "//:test_deps",
-        "@com_android_support_test_espresso_espresso_contrib_3_0_2_alpha1//aar",
     ],
 )
 

--- a/ui/uiautomator/BasicSample/BUILD.bazel
+++ b/ui/uiautomator/BasicSample/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+
 licenses(["notice"])  # Apache 2.0
 
 android_library(
@@ -23,7 +25,7 @@ android_library(
     deps = [
         ":BasicSampleLib",
         "//:test_deps",
-        "@com_android_support_test_uiautomator_uiautomator_v18_2_1_3//aar",
+        gmaven_artifact("com.android.support.test.uiautomator:uiautomator:aar:v18.2.1.3"),
     ],
 )
 


### PR DESCRIPTION
`gmaven_rules` has a new `gmaven_artifact` macro to let users specify the actual Maven artifact string instead of target names. This PR updates the WORKSPACE commits and applies that macro across all `gmaven_rules` targets.