### PR TITLE
Improve bazel.rc config and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Experimental Bazel Support
 
 Some of these samples can be built with [Bazel](https://bazel.build) on Linux. These samples contain a `BUILD.bazel` file, which is similar to a `build.gradle` file. The external dependencies are defined in the top level `WORKSPACE` file.
 
-This is __experimental__ feature. To run the tests, please install the latest version of Bazel (0.12.0rc2) from the [Bazel releases page](https://releases.bazel.build/0.12.0/rc2/index.html).
+This is __experimental__ feature. To run the tests, please install the latest version of Bazel (0.12.0 or later) by following the [instructions on the Bazel website](https://docs.bazel.build/versions/master/install-ubuntu.html).
 
 ### Bazel commands
 
@@ -110,7 +110,7 @@ $ bazel test //... --config=local_device
 $ bazel test //... --config=local_device --test_arg=--device_serial_number=$identifier
 ```
 
-For more information, check out the tutorial for [Building an Android App with Bazel](https://docs.bazel.build/versions/master/tutorial/android-app.html), and the list of [Android Rules](https://docs.bazel.build/versions/master/be/android.html) in the Bazel Build Encyclopedia.
+For more information, check out the documentation for [Android Instrumentation Tests in Bazel](https://docs.bazel.build/versions/master/android-instrumentation-test.html). You may also want to check out [Building an Android App with Bazel](https://docs.bazel.build/versions/master/tutorial/android-app.html), and the list of [Android Rules](https://docs.bazel.build/versions/master/be/android.html) in the Bazel Build Encyclopedia.
 
 Known issues:
 

--- a/README.md
+++ b/README.md
@@ -70,38 +70,44 @@ Experimental Bazel Support
 
 Some of these samples can be built with [Bazel](https://bazel.build) on Linux. These samples contain a `BUILD.bazel` file, which is similar to a `build.gradle` file. The external dependencies are defined in the top level `WORKSPACE` file.
 
-This is __experimental__ while testing features are being developed in Bazel. To run the tests, please use a development build of Bazel built from master:
+This is __experimental__ feature. To run the tests, please install the latest version of Bazel (0.12.0rc2) from the [Bazel releases page](https://releases.bazel.build/0.12.0/rc2/index.html).
+
+### Bazel commands
 
 ```
-$ git clone https://github.com/bazelbuild/bazel
-$ cd bazel
-$ bazel build //src:bazel # requires local installation of Bazel, please see https://docs.bazel.build/versions/master/install.html`
-$ cp bazel-bin/src/bazel /tmp/bazel
-```
-
-Then, to run the tests:
-
-```
+# Clone the repository if you haven't.
 $ git clone https://github.com/google/android-testing
 $ cd android-testing
 
 # Edit the path to your local SDK at the top of the WORKSPACE file
 $ $EDITOR WORKSPACE
 
-# Test everything in a headless mode
-$ /tmp/bazel test //... --config=headless
+# Test everything in a headless mode (no graphical display)
+$ bazel test //... --config=headless
 
 # Test a single test, e.g. ui/espresso/BasicSample/BUILD.bazel
-$ /tmp/bazel test //ui/espresso/BasicSample:BasicSampleInstrumentationTest --config=headless
+$ bazel test //ui/espresso/BasicSample:BasicSampleInstrumentationTest --config=headless
+
+# Query for all android_instrumentation_test targets
+$ bazel query 'kind(android_instrumentation_test, //...)'
+//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest
+//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest
+//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest
+//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest
+//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest
+//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest
+//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest
+//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest
+//ui/espresso/BasicSample:BasicSampleInstrumentationTest
 
 # Test everything with GUI enabled
-$ /tmp/bazel test //... --config=gui
+$ bazel test //... --config=gui
 
 # Test with a local device or emulator. Ensure that `adb devices` lists the device.
-$ /tmp/bazel test //... --config=local_adb
+$ bazel test //... --config=local_device
 
 # If multiple devices are connected, add --device_serial_number=$identifier where $identifier is the name of the device in `adb devices`
-$ /tmp/bazel test //... --config=local_adb --test_arg=--device_serial_number=$identifier
+$ bazel test //... --config=local_device --test_arg=--device_serial_number=$identifier
 ```
 
 For more information, check out the tutorial for [Building an Android App with Bazel](https://docs.bazel.build/versions/master/tutorial/android-app.html), and the list of [Android Rules](https://docs.bazel.build/versions/master/be/android.html) in the Bazel Build Encyclopedia.
@@ -110,7 +116,7 @@ Known issues:
 
 * Headless mode is unstable in sandboxed mode due to Xvfb issues.
 * Building of APKs is supported on Linux, Mac and Windows, but testing is only supported on Linux.
-* `android_instrumentation_test.target_device` attribute still needs to be specified even if `--config=local_adb` is used.
+* `android_instrumentation_test.target_device` attribute still needs to be specified even if `--config=local_device` is used.
 * If using a local device or emulator, the APKs are not uninstalled automatically after the test. Use this command to
 remove the packages:
     * `adb shell pm list packages com.example.android.testing | cut -d ':' -f 2 | tr -d '\r' | xargs -L1 -t adb uninstall`

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,16 +1,18 @@
 # Configurations for testing with Bazel
-# Select a configuration by running `bazel test //my:target --config={headless, gui, local_adb}`
+# Select a configuration by running `bazel test //my:target --config={headless, gui, local_device}`
 
 # Headless instrumentation tests
 test:headless --spawn_strategy=local
+test:headless --test_arg=--enable_display=false
 
 # Graphical instrumentation tests. Ensure that $DISPLAY is set.
 test:gui --test_env=DISPLAY
+test:gui --test_arg=--enable_display=true
 
 # Testing with a local emulator or device. Ensure that `adb devices` lists the device.
 # Run tests serially.
-test:local_adb --test_strategy=exclusive
+test:local_device --test_strategy=exclusive
 # Use the local device broker type, as opposed to WRAPPED_EMULATOR.
-test:local_adb --test_arg=--device_broker_type=LOCAL_ADB_SERVER
+test:local_device --test_arg=--device_broker_type=LOCAL_ADB_SERVER
 # Uncomment and set $device_id if there is more than one connected device.
-# test:local_adb --test_arg=--device_serial_number=$device_id
+# test:local_device --test_arg=--device_serial_number=$device_id


### PR DESCRIPTION
1) bazel.rc headless and gui configuration now pass --enable_display
test arg
2) Guide users to install Bazel 0.12.0
3) Added a command to query for all test targets