### PR TITLE
Use new androidx.test APIs and general cleanup.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "coreVersion", "espressoVersion", "extJUnitVersion", "extTruthVersion", "rulesVersion", "runnerVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -6,13 +7,13 @@ java_library(
     name = "test_deps",
     visibility = ["//visibility:public"],
     exports = [
-        gmaven_artifact("androidx.annotation:annotation:jar:1.0.0"),
-        gmaven_artifact("androidx.test.espresso:espresso-core:aar:3.1.0-beta02"),
-        gmaven_artifact("androidx.test:rules:aar:1.1.0-beta02"),
-        gmaven_artifact("androidx.test:runner:aar:1.1.0-beta02"),
-        gmaven_artifact("androidx.test:monitor:aar:1.1.0-beta02"),       
-        gmaven_artifact("androidx.test.ext:junit:aar:1.0.0-beta02"),       
-        gmaven_artifact("androidx.test:core:aar:1.0.0-beta02"),       
+        gmaven_artifact("androidx.annotation:annotation:jar:" + androidxLibVersion),
+        gmaven_artifact("androidx.test.espresso:espresso-core:aar:" + espressoVersion),
+        gmaven_artifact("androidx.test:rules:aar:" + rulesVersion),
+        gmaven_artifact("androidx.test:runner:aar:" + runnerVersion),
+        gmaven_artifact("androidx.test:monitor:aar:" + runnerVersion),
+        gmaven_artifact("androidx.test.ext:junit:aar:" + extJUnitVersion),
+        gmaven_artifact("androidx.test:core:aar:" + coreVersion),
         "@com_google_guava_guava//jar",
         "@com_google_inject_guice//jar",
         "@javax_inject_javax_inject//jar",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,7 +54,7 @@ maven_jar(
 
 maven_jar(
     name = "com_google_guava_guava",
-    artifact = "com.google.guava:guava:18.0",
+    artifact = "com.google.guava:guava:26.0-android",
 )
 
 maven_jar(

--- a/common_defs.bzl
+++ b/common_defs.bzl
@@ -1,0 +1,16 @@
+# Common constants for bazel builds
+
+# keep naming convention consistent with gradle variables, so version numbers can be auto-incremented
+# via a script
+
+androidxLibVersion = "1.0.0"
+coreVersion = "1.0.0-beta02"
+extJUnitVersion = "1.0.0-beta02"
+extTruthVersion = "1.0.0-beta02"
+runnerVersion = "1.1.0-beta02"
+rulesVersion = "1.1.0-beta02"
+espressoVersion = "3.1.0-beta02"
+uiAutomatorVersion = "2.2.0-beta02"
+
+minSdkVersion = "14"
+targetSdkVersion = "28"

--- a/runner/AndroidJunitRunnerSample/app/build.gradle
+++ b/runner/AndroidJunitRunnerSample/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.androidjunitrunnersample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -26,12 +26,11 @@ android {
 dependencies {
     // App's dependencies, including test
     implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion;
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:' + rootProject.guavaVersion
 
     // Testing-only dependencies
     androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
     androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
-    androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;
 }

--- a/runner/AndroidJunitRunnerSample/app/src/androidTest/java/com/example/android/testing/androidjunitrunnersample/CalculatorInstrumentationTest.java
+++ b/runner/AndroidJunitRunnerSample/app/src/androidTest/java/com/example/android/testing/androidjunitrunnersample/CalculatorInstrumentationTest.java
@@ -19,16 +19,16 @@ package com.example.android.testing.androidjunitrunnersample;
 import junit.framework.TestSuite;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.internal.builders.AllDefaultPossibilitiesBuilder;
 import org.junit.runner.RunWith;
 
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
 import androidx.test.runner.AndroidJUnitRunner;
 
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -51,23 +51,16 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 public class CalculatorInstrumentationTest {
 
     /**
-     * A JUnit {@link Rule @Rule} to launch your activity under test. This is a replacement
-     * for {@link android.test.ActivityInstrumentationTestCase2}.
-     * <p>
-     * Rules are interceptors which are executed for each test method and will run before
-     * any of your setup code in the {@link Before @Before} method.
-     * <p>
-     * {@link ActivityTestRule} will create and launch of the activity for you and also expose
-     * the activity under test. To get a reference to the activity you can use
-     * the {@link ActivityTestRule#getActivity()} method.
+     * Use {@link ActivityScenario} to create and launch of the activity.
      */
-    @Rule
-    public ActivityTestRule<CalculatorActivity> mActivityRule = new ActivityTestRule<>(
-            CalculatorActivity.class);
+    @Before
+    public void launchActivity() {
+        ActivityScenario.launch(CalculatorActivity.class);
+    }
 
     @Test
     public void noOperandShowsComputationError() {
-        final String expectedResult = mActivityRule.getActivity().getString(R.string.computationError);
+        final String expectedResult = getApplicationContext().getString(R.string.computationError);
         onView(withId(R.id.operation_add_btn)).perform(click());
         onView(withId(R.id.operation_result_text_view)).check(matches(withText(expectedResult)));
     }
@@ -89,8 +82,7 @@ public class CalculatorInstrumentationTest {
 
     @Test
     public void divZeroForOperandTwoShowsError() {
-        final String expectedResult = mActivityRule.getActivity().getString(
-                R.string.computationError);
+        final String expectedResult = getApplicationContext().getString(R.string.computationError);
         performOperation(R.id.operation_div_btn, "128.0", "0.0", expectedResult);
     }
 

--- a/runner/AndroidJunitRunnerSample/build.gradle
+++ b/runner/AndroidJunitRunnerSample/build.gradle
@@ -25,6 +25,7 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    guavaVersion = "26.0-android"
     coreVersion = "1.0.0-beta02"
     extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"

--- a/ui/espresso/BasicSample/BUILD.bazel
+++ b/ui/espresso/BasicSample/BUILD.bazel
@@ -1,5 +1,7 @@
 licenses(["notice"])  # Apache 2.0
 
+load("//:common_defs.bzl", "minSdkVersion", "targetSdkVersion")
+
 android_library(
     name = "BasicSampleLib",
     srcs = glob(["app/src/main/**/*.java"]),
@@ -23,6 +25,10 @@ android_binary(
     name = "BasicSample",
     custom_package = "com.example.android.testing.espresso.BasicSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":BasicSampleLib"],
 )
 
@@ -31,6 +37,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.BasicSample",
     instruments = ":BasicSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":BasicSampleTestLib"],
 )
 

--- a/ui/espresso/BasicSample/app/build.gradle
+++ b/ui/espresso/BasicSample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.BasicSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -22,10 +22,11 @@ android {
 dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion;
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:26.0-android'
 
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
-    androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;
 }

--- a/ui/espresso/BasicSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/BasicSample/app/src/androidTest/AndroidManifest.xml
@@ -19,7 +19,6 @@
       package="com.example.android.testing.espresso.BasicSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
     <instrumentation android:targetPackage="com.example.android.testing.espresso.BasicSample"
                      android:name="androidx.test.runner.AndroidJUnitRunner"/>

--- a/ui/espresso/BasicSample/app/src/androidTest/java/com/example/android/testing/espresso/BasicSample/ChangeTextBehaviorTest.java
+++ b/ui/espresso/BasicSample/app/src/androidTest/java/com/example/android/testing/espresso/BasicSample/ChangeTextBehaviorTest.java
@@ -22,10 +22,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import android.app.Activity;
+
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import static androidx.test.espresso.Espresso.onView;
@@ -50,19 +51,13 @@ public class ChangeTextBehaviorTest {
     public static final String STRING_TO_BE_TYPED = "Espresso";
 
     /**
-     * A JUnit {@link Rule @Rule} to launch your activity under test. This is a replacement
-     * for {@link android.test.ActivityInstrumentationTestCase2}.
-     * <p>
-     * Rules are interceptors which are executed for each test method and will run before
-     * any of your setup code in the {@link Before @Before} method.
-     * <p>
-     * {@link ActivityTestRule} will create and launch of the activity for you and also expose
-     * the activity under test. To get a reference to the activity you can use
-     * the {@link ActivityTestRule#getActivity()} method.
+     * Use {@link ActivityScenario} to create and launch the activity under test. This is a
+     * replacement for {@link androidx.test.rule.ActivityTestRule}.
      */
-    @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(
-            MainActivity.class);
+    @Before
+    public void launchActivity() {
+      ActivityScenario.launch(MainActivity.class);
+    }
 
     @Test
     public void changeText_sameActivity() {

--- a/ui/espresso/BasicSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/BasicSample/app/src/main/AndroidManifest.xml
@@ -18,8 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.testing.espresso.BasicSample" >
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/ui/espresso/BasicSample/build.gradle
+++ b/ui/espresso/BasicSample/build.gradle
@@ -25,7 +25,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
-    rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"
 }

--- a/ui/espresso/BasicSampleBundled/tests/com/example/android/testing/espresso/basicsamplebundled/tests/ChangeTextBehaviorTest.java
+++ b/ui/espresso/BasicSampleBundled/tests/com/example/android/testing/espresso/basicsamplebundled/tests/ChangeTextBehaviorTest.java
@@ -33,7 +33,7 @@ import android.app.Activity;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import com.example.android.testing.espresso.basicsamplebundled.MainActivity;

--- a/ui/espresso/CustomMatcherSample/BUILD.bazel
+++ b/ui/espresso/CustomMatcherSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,7 +10,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:1.0.0"),
+        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -18,6 +19,10 @@ android_binary(
     name = "CustomMatcherSample",
     custom_package = "com.example.android.testing.espresso.CustomMatcherSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":CustomMatcherSampleLib"],
 )
 
@@ -36,6 +41,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.CustomMatcherSample",
     instruments = ":CustomMatcherSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":CustomMatcherSampleTestLib"],
 )
 

--- a/ui/espresso/CustomMatcherSample/app/build.gradle
+++ b/ui/espresso/CustomMatcherSample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.CustomMatcherSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -28,9 +28,10 @@ android {
 dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:1.0.0';
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:26.0-android'
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
-    androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;
 }

--- a/ui/espresso/CustomMatcherSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/CustomMatcherSample/app/src/androidTest/AndroidManifest.xml
@@ -4,8 +4,6 @@
       package="com.example.android.testing.espresso.CustomMatcherSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <instrumentation android:targetPackage="com.example.android.testing.espresso.CustomMatcherSample"
                      android:name="androidx.test.runner.AndroidJUnitRunner"/>
 

--- a/ui/espresso/CustomMatcherSample/app/src/androidTest/java/com/example/android/testing/espresso/CustomMatcherSample/HintMatchersTest.java
+++ b/ui/espresso/CustomMatcherSample/app/src/androidTest/java/com/example/android/testing/espresso/CustomMatcherSample/HintMatchersTest.java
@@ -21,10 +21,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -51,27 +52,19 @@ public class HintMatchersTest {
 
     private static final String COFFEE_INVALID_ENDING = "tea?";
 
-    /**
-     * A JUnit {@link Rule @Rule} to launch your activity under test. This is a replacement
-     * for {@link android.test.ActivityInstrumentationTestCase2}.
-     * <p>
-     * Rules are interceptors which are executed for each test method and will run before
-     * any of your setup code in the {@link Before @Before} method.
-     * <p>
-     * {@link ActivityTestRule} will create and launch of the activity for you and also expose
-     * the activity under test. To get a reference to the activity you can use
-     * the {@link ActivityTestRule#getActivity()} method.
-     */
-    @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(
-            MainActivity.class);
-
     // A valid string with a valid ending
     private String mStringWithValidEnding;
 
     // A valid string from the coffee preparations
     private String mValidStringToBeTyped;
 
+    /**
+     * {@link ActivityScenario} will create and launch of the activity for you.
+     */
+    @Before
+    public void launchActivity() {
+        ActivityScenario.launch(MainActivity.class);
+    }
 
     @Before
     public void initValidStrings() {
@@ -87,7 +80,7 @@ public class HintMatchersTest {
      */
     @Test
     public void hint_isDisplayedInEditText() {
-        String hintText = mActivityRule.getActivity().getResources().getString(R.string.hint);
+        String hintText = getApplicationContext().getResources().getString(R.string.hint);
 
         onView(withId(R.id.editText)).check(matches(HintMatcher.withHint(hintText)));
     }

--- a/ui/espresso/CustomMatcherSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/CustomMatcherSample/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.example.android.testing.espresso.CustomMatcherSample">
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <application
             android:icon="@drawable/ic_launcher"
             android:label="@string/app_name"

--- a/ui/espresso/CustomMatcherSample/build.gradle
+++ b/ui/espresso/CustomMatcherSample/build.gradle
@@ -25,6 +25,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"

--- a/ui/espresso/DataAdapterSample/BUILD.bazel
+++ b/ui/espresso/DataAdapterSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,7 +10,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:1.0.0"),
+        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -18,6 +19,10 @@ android_binary(
     name = "DataAdapterSample",
     custom_package = "com.example.android.testing.espresso.DataAdapterSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":DataAdapterSampleLib"],
 )
 
@@ -36,6 +41,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.DataAdapterSample",
     instruments = ":DataAdapterSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":DataAdapterSampleTestLib"],
 )
 

--- a/ui/espresso/DataAdapterSample/app/build.gradle
+++ b/ui/espresso/DataAdapterSample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.DataAdapterSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -19,9 +19,10 @@ android {
 dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion;
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:26.0-android'
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
-    androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;
 }

--- a/ui/espresso/DataAdapterSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/DataAdapterSample/app/src/androidTest/AndroidManifest.xml
@@ -4,7 +4,6 @@
       package="com.example.android.testing.espresso.DataAdapterSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
     <instrumentation android:targetPackage="com.example.android.testing.espresso.DataAdapterSample"
                      android:name="androidx.test.runner.AndroidJUnitRunner"/>

--- a/ui/espresso/DataAdapterSample/app/src/androidTest/java/com/example/android/testing/espresso/DataAdapterSample/LongListActivityTest.java
+++ b/ui/espresso/DataAdapterSample/app/src/androidTest/java/com/example/android/testing/espresso/DataAdapterSample/LongListActivityTest.java
@@ -17,17 +17,16 @@
 package com.example.android.testing.espresso.DataAdapterSample;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.DataInteraction;
 import androidx.test.espresso.Espresso;
 import androidx.test.espresso.action.ViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
@@ -64,19 +63,13 @@ public class LongListActivityTest {
     private static final String LAST_ITEM_ID = "item: 99";
 
     /**
-     * A JUnit {@link Rule @Rule} to launch your activity under test. This is a replacement
-     * for {@link android.test.ActivityInstrumentationTestCase2}.
-     * <p>
-     * Rules are interceptors which are executed for each test method and will run before
-     * any of your setup code in the {@link Before @Before} method.
-     * <p>
-     * {@link ActivityTestRule} will create and launch of the activity for you and also expose
-     * the activity under test. To get a reference to the activity you can use
-     * the {@link ActivityTestRule#getActivity()} method.
+     * Use {@link ActivityScenario} to create and launch the activity under test. This is a
+     * replacement for {@link androidx.test.rule.ActivityTestRule}.
      */
-    @Rule
-    public ActivityTestRule<LongListActivity> mActivityRule = new ActivityTestRule<>(
-            LongListActivity.class);
+    @Before
+    public void launchActivity() {
+        ActivityScenario.launch(LongListActivity.class);
+    }
 
     /**
      * Test that the list is long enough for this sample, the last item shouldn't appear.

--- a/ui/espresso/DataAdapterSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/DataAdapterSample/app/src/main/AndroidManifest.xml
@@ -17,8 +17,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.testing.espresso.DataAdapterSample" >
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/ui/espresso/DataAdapterSample/build.gradle
+++ b/ui/espresso/DataAdapterSample/build.gradle
@@ -25,7 +25,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
-    rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"
 }

--- a/ui/espresso/IdlingResourceSample/BUILD.bazel
+++ b/ui/espresso/IdlingResourceSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "espressoVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,8 +10,8 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:1.0.0"),
-        gmaven_artifact("androidx.test.espresso:espresso-idling-resource:aar:3.1.0-beta02"),
+        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
+        gmaven_artifact("androidx.test.espresso:espresso-idling-resource:aar:" + espressoVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -19,6 +20,10 @@ android_binary(
     name = "IdlingResourceSample",
     custom_package = "com.example.android.testing.espresso.IdlingResourceSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":IdlingResourceSampleLib"],
 )
 
@@ -27,7 +32,7 @@ android_library(
     srcs = glob(["app/src/androidTest/**/*.java"]),
     custom_package = "com.example.android.testing.espresso.IdlingResourceSample",
     deps = [
-        gmaven_artifact("androidx.test.espresso:espresso_idling_resource:aar:3.1.0-beta02"),
+        gmaven_artifact("androidx.test.espresso:espresso_idling_resource:aar:" + espressoVersion),
         ":IdlingResourceSampleLib",
         "//:test_deps",
     ],
@@ -38,6 +43,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.IdlingResourceSample",
     instruments = ":IdlingResourceSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":IdlingResourceSampleTestLib"],
 )
 

--- a/ui/espresso/IdlingResourceSample/app/build.gradle
+++ b/ui/espresso/IdlingResourceSample/app/build.gradle
@@ -17,13 +17,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.android.testing.espresso.IdlingResourceSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -37,11 +37,12 @@ android {
 dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:26.0-android'
 
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion
-    androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;
     // Note that espresso-idling-resource is used in the code under test.
     implementation 'androidx.test.espresso:espresso-idling-resource:' + rootProject.espressoVersion;

--- a/ui/espresso/IdlingResourceSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/IdlingResourceSample/app/src/androidTest/AndroidManifest.xml
@@ -4,7 +4,6 @@
       package="com.example.android.testing.espresso.IdlingResourceSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
     <instrumentation android:targetPackage="com.example.android.testing.espresso.IdlingResourceSample"
                      android:name="androidx.test.runner.AndroidJUnitRunner"/>

--- a/ui/espresso/IdlingResourceSample/app/src/androidTest/java/com/example/android/testing/espresso/IdlingResourceSample/ChangeTextBehaviorTest.java
+++ b/ui/espresso/IdlingResourceSample/app/src/androidTest/java/com/example/android/testing/espresso/IdlingResourceSample/ChangeTextBehaviorTest.java
@@ -24,15 +24,14 @@ import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
-import androidx.test.espresso.Espresso;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.espresso.IdlingResource;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,17 +45,25 @@ public class ChangeTextBehaviorTest {
 
     private static final String STRING_TO_BE_TYPED = "Espresso";
 
-    @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(
-            MainActivity.class);
-
     private IdlingResource mIdlingResource;
 
+
+    /**
+     * Use {@link ActivityScenario to launch and get access to the activity.
+     * {@link ActivityScenario#onActivity(ActivityScenario.ActivityAction)} provides a thread-safe
+     * mechanism to access the activity.
+     */
     @Before
     public void registerIdlingResource() {
-        mIdlingResource = mActivityRule.getActivity().getIdlingResource();
-        // To prove that the test fails, omit this call:
-        Espresso.registerIdlingResources(mIdlingResource);
+        ActivityScenario activityScenario = ActivityScenario.launch(MainActivity.class);
+        activityScenario.onActivity(new ActivityScenario.ActivityAction<MainActivity>() {
+            @Override
+            public void perform(MainActivity activity) {
+                mIdlingResource = activity.getIdlingResource();
+                // To prove that the test fails, omit this call:
+                IdlingRegistry.getInstance().register(mIdlingResource);
+            }
+        });
     }
 
     @Test
@@ -73,7 +80,7 @@ public class ChangeTextBehaviorTest {
     @After
     public void unregisterIdlingResource() {
         if (mIdlingResource != null) {
-            Espresso.unregisterIdlingResources(mIdlingResource);
+            IdlingRegistry.getInstance().unregister(mIdlingResource);
         }
     }
 }

--- a/ui/espresso/IdlingResourceSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/IdlingResourceSample/app/src/main/AndroidManifest.xml
@@ -17,11 +17,7 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.testing.espresso.IdlingResourceSample" >
-
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
-    <application
-        android:icon="@drawable/ic_launcher"
+    <application android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity

--- a/ui/espresso/IdlingResourceSample/build.gradle
+++ b/ui/espresso/IdlingResourceSample/build.gradle
@@ -41,7 +41,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
-    rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"
 }

--- a/ui/espresso/IntentsAdvancedSample/BUILD.bazel
+++ b/ui/espresso/IntentsAdvancedSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "espressoVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,7 +10,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:1.0.0"),
+        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -18,6 +19,10 @@ android_binary(
     name = "IntentsAdvancedSample",
     custom_package = "com.example.android.testing.espresso.intents.AdvancedSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":IntentsAdvancedSampleLib"],
 )
 
@@ -26,7 +31,7 @@ android_library(
     srcs = glob(["app/src/androidTest/**/*.java"]),
     custom_package = "com.example.android.testing.espresso.intents.AdvancedSample",
     deps = [
-        gmaven_artifact("androidx.test.espresso:espresso-intents:aar:3.1.0-beta02"),
+        gmaven_artifact("androidx.test.espresso:espresso-intents:aar:" + espressoVersion),
         ":IntentsAdvancedSampleLib",
         "//:test_deps",
     ],
@@ -37,6 +42,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.intents.AdvancedSample",
     instruments = ":IntentsAdvancedSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":IntentsAdvancedSampleTestLib"],
 )
 

--- a/ui/espresso/IntentsAdvancedSample/app/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.intents.AdvancedSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -23,6 +23,8 @@ dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion;
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
     androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;

--- a/ui/espresso/IntentsAdvancedSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/IntentsAdvancedSample/app/src/androidTest/AndroidManifest.xml
@@ -4,7 +4,6 @@
       package="com.example.android.testing.espresso.intents.AdvancedSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/ui/espresso/IntentsAdvancedSample/app/src/androidTest/java/com/example/android/testing/espresso/intents/AdvancedSample/ImageViewerActivityTest.java
+++ b/ui/espresso/IntentsAdvancedSample/app/src/androidTest/java/com/example/android/testing/espresso/intents/AdvancedSample/ImageViewerActivityTest.java
@@ -22,9 +22,8 @@ import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.provider.MediaStore;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Before;
 import org.junit.Rule;

--- a/ui/espresso/IntentsAdvancedSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/IntentsAdvancedSample/app/src/main/AndroidManifest.xml
@@ -18,8 +18,6 @@
 <manifest package="com.example.android.testing.espresso.intents.AdvancedSample"
           xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <uses-feature
         android:name="android.hardware.camera"
         android:required="true"/>

--- a/ui/espresso/IntentsAdvancedSample/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/build.gradle
@@ -25,6 +25,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"

--- a/ui/espresso/IntentsBasicSample/BUILD.bazel
+++ b/ui/espresso/IntentsBasicSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "coreVersion", "espressoVersion", "extTruthVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,8 +10,8 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:1.0.0"),
-        gmaven_artifact("androidx.core:core:aar:1.0.0"),
+        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
+        gmaven_artifact("androidx.core:core:aar:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -19,6 +20,10 @@ android_binary(
     name = "IntentsBasicSample",
     custom_package = "com.example.android.testing.espresso.BasicSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":IntentsBasicSampleLib"],
 )
 
@@ -29,9 +34,9 @@ android_library(
     deps = [
         ":IntentsBasicSampleLib",
         "//:test_deps",
-        gmaven_artifact("androidx.test.espresso:espresso-intents:aar:3.1.0-beta02"),
-        gmaven_artifact("androidx.test.ext:truth:aar:1.0.0-beta02"),
-	"@truth//jar",
+        gmaven_artifact("androidx.test.espresso:espresso-intents:aar:" + espressoVersion),
+        gmaven_artifact("androidx.test.ext:truth:aar:" + extTruthVersion),
+        "@truth//jar",
     ],
 )
 
@@ -40,6 +45,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.BasicSample",
     instruments = ":IntentsBasicSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":IntentsBasicSampleTestLib"],
 )
 

--- a/ui/espresso/IntentsBasicSample/app/build.gradle
+++ b/ui/espresso/IntentsBasicSample/app/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:' + rootProject.androidxLibVersion;
 
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
     androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;

--- a/ui/espresso/IntentsBasicSample/app/src/androidTest/java/com/example/android/testing/espresso/BasicSample/DialerActivityTest.java
+++ b/ui/espresso/IntentsBasicSample/app/src/androidTest/java/com/example/android/testing/espresso/BasicSample/DialerActivityTest.java
@@ -17,8 +17,8 @@
 package com.example.android.testing.espresso.BasicSample;
 
 import static android.app.Instrumentation.ActivityResult;
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
-import static androidx.test.InstrumentationRegistry.getTargetContext;
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
@@ -48,7 +48,7 @@ import androidx.test.espresso.intent.Intents;
 import androidx.test.espresso.intent.rule.IntentsTestRule;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import com.google.common.collect.Iterables;
 
@@ -101,7 +101,7 @@ public class DialerActivityTest {
         // the permission is granted before running this test.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             getInstrumentation().getUiAutomation().executeShellCommand(
-                    "pm grant " + getTargetContext().getPackageName()
+                    "pm grant " + getApplicationContext().getPackageName()
                             + " android.permission.CALL_PHONE");
         }
     }

--- a/ui/espresso/IntentsBasicSample/build.gradle
+++ b/ui/espresso/IntentsBasicSample/build.gradle
@@ -25,6 +25,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"

--- a/ui/espresso/MultiProcessSample/app/build.gradle
+++ b/ui/espresso/MultiProcessSample/app/build.gradle
@@ -17,12 +17,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "28.0.2"
+    compileSdkVersion 28
+    buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.multiprocesssample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -37,8 +37,10 @@ android {
 
 dependencies {
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-alpha4'
-    androidTestImplementation 'androidx.test.espresso:espresso-remote:3.1.0-alpha4'
-    androidTestImplementation "androidx.test:runner:1.1.0-alpha4"
-    androidTestImplementation "androidx.test:rules:1.1.0-alpha4"
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion
+    androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion
+    androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion
+    androidTestImplementation 'androidx.test.espresso:espresso-remote:' + rootProject.espressoVersion
+    androidTestImplementation "androidx.test:runner:" + rootProject.runnerVersion
 }

--- a/ui/espresso/MultiProcessSample/app/src/androidTest/java/com/example/android/testing/espresso/multiprocesssample/ExampleInstrumentedTest.java
+++ b/ui/espresso/MultiProcessSample/app/src/androidTest/java/com/example/android/testing/espresso/multiprocesssample/ExampleInstrumentedTest.java
@@ -16,11 +16,12 @@
 
 package com.example.android.testing.espresso.multiprocesssample;
 
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.util.Log;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,9 +45,10 @@ public class ExampleInstrumentedTest {
     private static final String DEFAULT_PROC_NAME =
             "com.example.android.testing.espresso.multiprocesssample";
 
-    @Rule
-    public ActivityTestRule<DefaultProcessActivity> rule =
-            new ActivityTestRule<>(DefaultProcessActivity.class);
+    @Before
+    public void launchActivity() {
+        ActivityScenario.launch(DefaultProcessActivity.class);
+    }
 
     @Test
     public void verifyAssertingOnViewInRemoteProcessIsSuccessful() {

--- a/ui/espresso/MultiProcessSample/build.gradle
+++ b/ui/espresso/MultiProcessSample/build.gradle
@@ -41,3 +41,13 @@ allprojects {
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+
+ext {
+    buildToolsVersion = "28.0.3"
+    androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
+    runnerVersion = "1.1.0-beta02"
+    rulesVersion = "1.1.0-beta02"
+    espressoVersion = "3.1.0-beta02"
+}

--- a/ui/espresso/MultiWindowSample/BUILD.bazel
+++ b/ui/espresso/MultiWindowSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,7 +10,7 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.annotation:annotation:jar:1.0.0"),
+        gmaven_artifact("androidx.annotation:annotation:jar:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -18,6 +19,10 @@ android_binary(
     name = "MultiWindowSample",
     custom_package = "com.example.android.testing.espresso.MultiWindowSample",
     manifest = "app/src/main/AppManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":MultiWindowSampleLib"],
 )
 
@@ -36,6 +41,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.MultiWindowSample",
     instruments = ":MultiWindowSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":MultiWindowSampleTestLib"],
 )
 

--- a/ui/espresso/MultiWindowSample/app/build.gradle
+++ b/ui/espresso/MultiWindowSample/app/build.gradle
@@ -2,12 +2,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.MultiWindowSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -29,8 +29,10 @@ android {
 dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:' + rootProject.androidxLibVersion;
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:' + rootProject.guavaVersion
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
     androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;

--- a/ui/espresso/MultiWindowSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/MultiWindowSample/app/src/androidTest/AndroidManifest.xml
@@ -4,7 +4,6 @@
       package="com.example.android.testing.espresso.MultiWindowSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
     <instrumentation android:targetPackage="com.example.android.testing.espresso.MultiWindowSample"
                      android:name="androidx.test.runner.AndroidJUnitRunner"/>

--- a/ui/espresso/MultiWindowSample/app/src/androidTest/java/com/example/android/testing/espresso/MultiWindowSample/MultiWindowTest.java
+++ b/ui/espresso/MultiWindowSample/app/src/androidTest/java/com/example/android/testing/espresso/MultiWindowSample/MultiWindowTest.java
@@ -16,8 +16,8 @@
 package com.example.android.testing.espresso.MultiWindowSample;
 
 import androidx.test.filters.LargeTest;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -155,7 +155,6 @@ public class MultiWindowTest {
         onView(withId(R.id.auto_complete_text_view))
                 .check(matches(withText("Baltic Sea")));
     }
-
 }
 
 

--- a/ui/espresso/MultiWindowSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/MultiWindowSample/app/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.testing.espresso.MultiWindowSample" >
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/ui/espresso/MultiWindowSample/build.gradle
+++ b/ui/espresso/MultiWindowSample/build.gradle
@@ -25,7 +25,11 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    guavaVersion = "26.0-android"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"
 }
+

--- a/ui/espresso/RecyclerViewSample/BUILD.bazel
+++ b/ui/espresso/RecyclerViewSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "androidxLibVersion", "espressoVersion", "minSdkVersion", "targetSdkVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -9,8 +10,8 @@ android_library(
     manifest = "app/src/main/AndroidManifest.xml",
     resource_files = glob(["app/src/main/res/**/*"]),
     deps = [
-        gmaven_artifact("androidx.recyclerview:recyclerview:aar:1.0.0"),
-        gmaven_artifact("androidx.annotation:annotation:1.0.0"),
+        gmaven_artifact("androidx.recyclerview:recyclerview:aar:" + androidxLibVersion),
+        gmaven_artifact("androidx.annotation:annotation:" + androidxLibVersion),
         "@com_google_guava_guava//jar",
     ],
 )
@@ -27,7 +28,7 @@ android_library(
     srcs = glob(["app/src/androidTest/**/*.java"]),
     custom_package = "com.example.android.testing.espresso.RecyclerViewSample",
     deps = [
-        gmaven_artifact("androidx.test.espresso:espresso-contrib:aar:3.1.0-beta02"),
+        gmaven_artifact("androidx.test.espresso:espresso-contrib:aar:" + espressoVersion),
         ":RecyclerViewSampleLib",
         "//:test_deps",
     ],
@@ -38,6 +39,10 @@ android_binary(
     custom_package = "com.example.android.testing.espresso.RecyclerViewSample",
     instruments = ":RecyclerViewSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
+    manifest_values = {
+        "minSdkVersion": minSdkVersion,
+        "targetSdkVersion": targetSdkVersion,
+    },
     deps = [":RecyclerViewSampleTestLib"],
 )
 

--- a/ui/espresso/RecyclerViewSample/app/build.gradle
+++ b/ui/espresso/RecyclerViewSample/app/build.gradle
@@ -17,7 +17,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.RecyclerViewSample"
@@ -39,8 +39,9 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:' + rootProject.androidxLibVersion;
 
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
-    androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-core:' + rootProject.espressoVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:' + rootProject.espressoVersion;
 

--- a/ui/espresso/RecyclerViewSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/RecyclerViewSample/app/src/androidTest/AndroidManifest.xml
@@ -4,7 +4,6 @@
       package="com.example.android.testing.espresso.RecyclerViewSample"
       android:versionCode="1"
       android:versionName="1.0">
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
     <instrumentation android:targetPackage="com.example.android.testing.espresso.RecyclerViewSample"
                      android:name="androidx.test.runner.AndroidJUnitRunner"/>

--- a/ui/espresso/RecyclerViewSample/app/src/androidTest/java/com/example/android/testing/espresso/RecyclerViewSample/RecyclerViewSampleTest.java
+++ b/ui/espresso/RecyclerViewSample/app/src/androidTest/java/com/example/android/testing/espresso/RecyclerViewSample/RecyclerViewSampleTest.java
@@ -16,22 +16,23 @@
 
 package com.example.android.testing.espresso.RecyclerViewSample;
 
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.contrib.RecyclerViewActions;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.filters.LargeTest;
-import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
-import org.junit.Rule;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,9 +46,14 @@ public class RecyclerViewSampleTest {
 
     private static final int ITEM_BELOW_THE_FOLD = 40;
 
-    @Rule
-    public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(
-            MainActivity.class);
+    /**
+     * Use {@link ActivityScenario} to create and launch the activity under test. This is a
+     * replacement for {@link androidx.test.rule.ActivityTestRule}.
+     */
+    @Before
+    public void launchActivity() {
+        ActivityScenario.launch(MainActivity.class);
+    }
 
     @Test
     public void scrollToItemBelowFold_checkItsText() {
@@ -56,7 +62,7 @@ public class RecyclerViewSampleTest {
                 .perform(RecyclerViewActions.actionOnItemAtPosition(ITEM_BELOW_THE_FOLD, click()));
 
         // Match the text in an item below the fold and check that it's displayed.
-        String itemElementText = mActivityRule.getActivity().getResources().getString(
+        String itemElementText = getApplicationContext().getResources().getString(
                 R.string.item_element_text) + String.valueOf(ITEM_BELOW_THE_FOLD);
         onView(withText(itemElementText)).check(matches(isDisplayed()));
     }
@@ -69,7 +75,7 @@ public class RecyclerViewSampleTest {
 
         // Check that the item has the special text.
         String middleElementText =
-                mActivityRule.getActivity().getResources().getString(R.string.middle);
+                getApplicationContext().getResources().getString(R.string.middle);
         onView(withText(middleElementText)).check(matches(isDisplayed()));
     }
 

--- a/ui/espresso/RecyclerViewSample/app/src/main/AndroidManifest.xml
+++ b/ui/espresso/RecyclerViewSample/app/src/main/AndroidManifest.xml
@@ -18,8 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.android.testing.espresso.RecyclerViewSample" >
 
-    <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
-
     <application
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"

--- a/ui/espresso/RecyclerViewSample/build.gradle
+++ b/ui/espresso/RecyclerViewSample/build.gradle
@@ -41,6 +41,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"

--- a/ui/espresso/WebBasicSample/app/build.gradle
+++ b/ui/espresso/WebBasicSample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.web.BasicSample"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -26,8 +26,10 @@ android {
 dependencies {
     // App dependencies
     implementation 'androidx.annotation:annotation:'+ rootProject.androidxLibVersion;
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:' + rootProject.guavaVersion
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
     androidTestImplementation 'androidx.test:rules:' + rootProject.rulesVersion;
     androidTestImplementation 'androidx.test.espresso:espresso-web:' + rootProject.espressoVersion;

--- a/ui/espresso/WebBasicSample/app/src/androidTest/java/com/example/android/testing/espresso/web/BasicSample/WebViewActivityTest.java
+++ b/ui/espresso/WebBasicSample/app/src/androidTest/java/com/example/android/testing/espresso/web/BasicSample/WebViewActivityTest.java
@@ -22,12 +22,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import android.content.Intent;
+
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.espresso.web.sugar.Web;
 import androidx.test.espresso.web.webdriver.DriverAtoms;
 import androidx.test.espresso.web.webdriver.Locator;
 import androidx.test.filters.LargeTest;
 import androidx.test.rule.ActivityTestRule;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.webkit.WebView;
 
 import static androidx.test.espresso.web.assertion.WebViewAssertions.webMatches;

--- a/ui/espresso/WebBasicSample/build.gradle
+++ b/ui/espresso/WebBasicSample/build.gradle
@@ -25,6 +25,9 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    guavaVersion = "26.0-android"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"

--- a/ui/uiautomator/BasicSample/BUILD.bazel
+++ b/ui/uiautomator/BasicSample/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
+load("//:common_defs.bzl", "uiAutomatorVersion")
 
 licenses(["notice"])  # Apache 2.0
 
@@ -25,7 +26,7 @@ android_library(
     deps = [
         ":BasicSampleLib",
         "//:test_deps",
-        gmaven_artifact("androidx.test.uiautomator:uiautomator:aar:2.2.0-beta02"),
+        gmaven_artifact("androidx.test.uiautomator:uiautomator:aar:" + uiAutomatorVersion),
     ],
 )
 

--- a/ui/uiautomator/BasicSample/app/build.gradle
+++ b/ui/uiautomator/BasicSample/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.uiautomator.BasicSample"
         minSdkVersion 18
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
 
@@ -23,8 +23,10 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.guava:guava:18.0'
+    implementation 'com.google.guava:guava:26.0-android'
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
     // UiAutomator Testing
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:' + rootProject.uiautomatorVersion;

--- a/ui/uiautomator/BasicSample/app/src/androidTest/java/com/example/android/testing/uiautomator/BasicSample/ChangeTextBehaviorTest.java
+++ b/ui/uiautomator/BasicSample/app/src/androidTest/java/com/example/android/testing/uiautomator/BasicSample/ChangeTextBehaviorTest.java
@@ -24,9 +24,11 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
-import androidx.test.InstrumentationRegistry;
+
+import static androidx.test.core.app.ApplicationProvider.getApplicationContext;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import androidx.test.filters.SdkSuppress;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
 import androidx.test.uiautomator.UiObject2;
@@ -56,7 +58,7 @@ public class ChangeTextBehaviorTest {
     @Before
     public void startMainActivityFromHomeScreen() {
         // Initialize UiDevice instance
-        mDevice = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
+        mDevice = UiDevice.getInstance(getInstrumentation());
 
         // Start from the home screen
         mDevice.pressHome();
@@ -67,7 +69,7 @@ public class ChangeTextBehaviorTest {
         mDevice.wait(Until.hasObject(By.pkg(launcherPackage).depth(0)), LAUNCH_TIMEOUT);
 
         // Launch the blueprint app
-        Context context = InstrumentationRegistry.getContext();
+        Context context = getApplicationContext();
         final Intent intent = context.getPackageManager()
                 .getLaunchIntentForPackage(BASIC_SAMPLE_PACKAGE);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);    // Clear out any previous instances
@@ -123,7 +125,7 @@ public class ChangeTextBehaviorTest {
         intent.addCategory(Intent.CATEGORY_HOME);
 
         // Use PackageManager to get the launcher package name
-        PackageManager pm = InstrumentationRegistry.getContext().getPackageManager();
+        PackageManager pm = getApplicationContext().getPackageManager();
         ResolveInfo resolveInfo = pm.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
         return resolveInfo.activityInfo.packageName;
     }

--- a/ui/uiautomator/BasicSample/build.gradle
+++ b/ui/uiautomator/BasicSample/build.gradle
@@ -22,6 +22,8 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     rulesVersion = "1.1.0-beta02"
     espressoVersion = "3.1.0-beta02"

--- a/unit/BasicUnitAndroidTest/app/build.gradle
+++ b/unit/BasicUnitAndroidTest/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.android.testing.unittesting.basicunitandroidtest"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -16,6 +16,8 @@ android {
 
 dependencies {
     // Testing-only dependencies
+    androidTestImplementation 'androidx.test:core:' + rootProject.coreVersion;
+    androidTestImplementation 'androidx.test.ext:junit:' + rootProject.extJUnitVersion;
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion;
-    androidTestImplementation 'org.hamcrest:hamcrest-library:' + rootProject.hamcrestVersion;
+    androidTestImplementation 'com.google.truth:truth:' + rootProject.truthVersion
 }

--- a/unit/BasicUnitAndroidTest/app/src/androidTest/java/com/example/android/testing/unittesting/basicunitandroidtest/LogHistoryAndroidUnitTest.java
+++ b/unit/BasicUnitAndroidTest/app/src/androidTest/java/com/example/android/testing/unittesting/basicunitandroidtest/LogHistoryAndroidUnitTest.java
@@ -18,7 +18,7 @@ package com.example.android.testing.unittesting.basicunitandroidtest;
 
 import android.os.Parcel;
 import androidx.test.filters.SmallTest;
-import androidx.test.runner.AndroidJUnit4;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.util.Pair;
 
 import org.junit.Before;
@@ -27,8 +27,7 @@ import org.junit.runner.RunWith;
 
 import java.util.List;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Tests that the parcelable interface is implemented correctly.
@@ -63,8 +62,8 @@ public class LogHistoryAndroidUnitTest {
         List<Pair<String, Long>> createdFromParcelData = createdFromParcel.getData();
 
         // Verify that the received data is correct.
-        assertThat(createdFromParcelData.size(), is(1));
-        assertThat(createdFromParcelData.get(0).first, is(TEST_STRING));
-        assertThat(createdFromParcelData.get(0).second, is(TEST_LONG));
+        assertThat(createdFromParcelData.size()).isEqualTo(1);
+        assertThat(createdFromParcelData.get(0).first).isEqualTo(TEST_STRING);
+        assertThat(createdFromParcelData.get(0).second).isEqualTo(TEST_LONG);
     }
 }

--- a/unit/BasicUnitAndroidTest/build.gradle
+++ b/unit/BasicUnitAndroidTest/build.gradle
@@ -25,6 +25,9 @@ allprojects {
 ext {
     buildToolsVersion = "28.0.3"
     androidxLibVersion = "1.0.0"
+    coreVersion = "1.0.0-beta02"
+    extJUnitVersion = "1.0.0-beta02"
     runnerVersion = "1.1.0-beta02"
     hamcrestVersion = "1.3"
+    truthVersion = "0.42"
 }


### PR DESCRIPTION
  - Use new AndroidJUnit4, ApplicationProvider, and ActivityScenario
    APIs wherever possible.
  - Set compile/min/target sdk versions to 28,14,28 consistently
  - Define min and target sdk versions in build files not manifest, to
    appease gradle+studio
  - Use constants to define versions in bazel builds
  - Update to guava 26.0-android consistently