### PR TITLE
Update android/android-test commit, actually fix Starlark http_archive incompatible change

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,7 +9,7 @@ android_sdk_repository(
 )
 
 # Android Test Support
-ATS_COMMIT = "c69935b7c09aa2074588013b2159ba1972f31952"
+ATS_COMMIT = "66c68ee36b7541b0134f53d5f5ee88e13bdadc29"
 
 http_archive(
     name = "android_test_support",


### PR DESCRIPTION
tested on 0.19.0.

`bazel clean --expunge && bazel build //... --incompatible_remove_native_http_archive=true`

cc @meteorcloudy