### PR TITLE
Fix all Bazel-enabled tests to pass with Bazel on HEAD again

### DIFF
--- a/ui/espresso/BasicSample/BUILD.bazel
+++ b/ui/espresso/BasicSample/BUILD.bazel
@@ -11,16 +11,6 @@ android_library(
     deps = ["@com_google_guava_guava//jar"],
 )
 
-android_library(
-    name = "BasicSampleTestLib",
-    srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.BasicSample",
-    deps = [
-        ":BasicSampleLib",
-        "//:test_deps",
-    ],
-)
-
 android_binary(
     name = "BasicSample",
     custom_package = "com.example.android.testing.espresso.BasicSample",
@@ -32,9 +22,19 @@ android_binary(
     deps = [":BasicSampleLib"],
 )
 
+android_library(
+    name = "BasicSampleTestLib",
+    srcs = glob(["app/src/androidTest/**/*.java"]),
+    custom_package = "com.example.android.testing.espresso.BasicSample.test",
+    deps = [
+        ":BasicSampleLib",
+        "//:test_deps",
+    ],
+)
+
 android_binary(
     name = "BasicSampleTest",
-    custom_package = "com.example.android.testing.espresso.BasicSample",
+    custom_package = "com.example.android.testing.espresso.BasicSample.test",
     instruments = ":BasicSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/BasicSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/BasicSample/app/src/androidTest/AndroidManifest.xml
@@ -16,7 +16,7 @@
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.BasicSample"
+      package="com.example.android.testing.espresso.BasicSample.test"
       android:versionCode="1"
       android:versionName="1.0">
 

--- a/ui/espresso/CustomMatcherSample/BUILD.bazel
+++ b/ui/espresso/CustomMatcherSample/BUILD.bazel
@@ -29,7 +29,7 @@ android_binary(
 android_library(
     name = "CustomMatcherSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.CustomMatcherSample",
+    custom_package = "com.example.android.testing.espresso.CustomMatcherSample.test",
     deps = [
         ":CustomMatcherSampleLib",
         "//:test_deps",
@@ -38,7 +38,7 @@ android_library(
 
 android_binary(
     name = "CustomMatcherSampleTest",
-    custom_package = "com.example.android.testing.espresso.CustomMatcherSample",
+    custom_package = "com.example.android.testing.espresso.CustomMatcherSample.test",
     instruments = ":CustomMatcherSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/CustomMatcherSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/CustomMatcherSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.CustomMatcherSample"
+      package="com.example.android.testing.espresso.CustomMatcherSample.test"
       android:versionCode="1"
       android:versionName="1.0">
     <instrumentation android:targetPackage="com.example.android.testing.espresso.CustomMatcherSample"

--- a/ui/espresso/DataAdapterSample/BUILD.bazel
+++ b/ui/espresso/DataAdapterSample/BUILD.bazel
@@ -29,7 +29,7 @@ android_binary(
 android_library(
     name = "DataAdapterSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.DataAdapterSample",
+    custom_package = "com.example.android.testing.espresso.DataAdapterSample.test",
     deps = [
         ":DataAdapterSampleLib",
         "//:test_deps",
@@ -38,7 +38,7 @@ android_library(
 
 android_binary(
     name = "DataAdapterSampleTest",
-    custom_package = "com.example.android.testing.espresso.DataAdapterSample",
+    custom_package = "com.example.android.testing.espresso.DataAdapterSample.test",
     instruments = ":DataAdapterSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/DataAdapterSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/DataAdapterSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.DataAdapterSample"
+      package="com.example.android.testing.espresso.DataAdapterSample.test"
       android:versionCode="1"
       android:versionName="1.0">
 

--- a/ui/espresso/IdlingResourceSample/BUILD.bazel
+++ b/ui/espresso/IdlingResourceSample/BUILD.bazel
@@ -30,7 +30,7 @@ android_binary(
 android_library(
     name = "IdlingResourceSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.IdlingResourceSample",
+    custom_package = "com.example.android.testing.espresso.IdlingResourceSample.test",
     deps = [
         gmaven_artifact("androidx.test.espresso:espresso_idling_resource:aar:" + espressoVersion),
         ":IdlingResourceSampleLib",
@@ -40,7 +40,7 @@ android_library(
 
 android_binary(
     name = "IdlingResourceSampleTest",
-    custom_package = "com.example.android.testing.espresso.IdlingResourceSample",
+    custom_package = "com.example.android.testing.espresso.IdlingResourceSample.test",
     instruments = ":IdlingResourceSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/IdlingResourceSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/IdlingResourceSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.IdlingResourceSample"
+      package="com.example.android.testing.espresso.IdlingResourceSample.test"
       android:versionCode="1"
       android:versionName="1.0">
 

--- a/ui/espresso/IntentsAdvancedSample/BUILD.bazel
+++ b/ui/espresso/IntentsAdvancedSample/BUILD.bazel
@@ -29,7 +29,7 @@ android_binary(
 android_library(
     name = "IntentsAdvancedSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.intents.AdvancedSample",
+    custom_package = "com.example.android.testing.espresso.intents.AdvancedSample.test",
     deps = [
         gmaven_artifact("androidx.test.espresso:espresso-intents:aar:" + espressoVersion),
         ":IntentsAdvancedSampleLib",
@@ -39,7 +39,7 @@ android_library(
 
 android_binary(
     name = "IntentsAdvancedSampleTest",
-    custom_package = "com.example.android.testing.espresso.intents.AdvancedSample",
+    custom_package = "com.example.android.testing.espresso.intents.AdvancedSample.test",
     instruments = ":IntentsAdvancedSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/IntentsAdvancedSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/IntentsAdvancedSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.intents.AdvancedSample"
+      package="com.example.android.testing.espresso.intents.AdvancedSample.test"
       android:versionCode="1"
       android:versionName="1.0">
 

--- a/ui/espresso/IntentsBasicSample/BUILD.bazel
+++ b/ui/espresso/IntentsBasicSample/BUILD.bazel
@@ -30,7 +30,7 @@ android_binary(
 android_library(
     name = "IntentsBasicSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.BasicSample",
+    custom_package = "com.example.android.testing.espresso.BasicSample.test",
     deps = [
         ":IntentsBasicSampleLib",
         "//:test_deps",
@@ -42,7 +42,7 @@ android_library(
 
 android_binary(
     name = "IntentsBasicSampleTest",
-    custom_package = "com.example.android.testing.espresso.BasicSample",
+    custom_package = "com.example.android.testing.espresso.BasicSample.test",
     instruments = ":IntentsBasicSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/IntentsBasicSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/IntentsBasicSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.BasicSample"
+      package="com.example.android.testing.espresso.BasicSample.test"
       android:versionCode="1"
       android:versionName="1.0">
     <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />

--- a/ui/espresso/IntentsBasicSample/app/src/main/AppManifest.xml
+++ b/ui/espresso/IntentsBasicSample/app/src/main/AppManifest.xml
@@ -20,4 +20,5 @@
 
     <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="28" />
 
+    <uses-permission android:name="android.permission.CALL_PHONE"/>
 </manifest>

--- a/ui/espresso/MultiWindowSample/BUILD.bazel
+++ b/ui/espresso/MultiWindowSample/BUILD.bazel
@@ -29,7 +29,7 @@ android_binary(
 android_library(
     name = "MultiWindowSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.MultiWindowSample",
+    custom_package = "com.example.android.testing.espresso.MultiWindowSample.test",
     deps = [
         ":MultiWindowSampleLib",
         "//:test_deps",
@@ -38,7 +38,7 @@ android_library(
 
 android_binary(
     name = "MultiWindowSampleTest",
-    custom_package = "com.example.android.testing.espresso.MultiWindowSample",
+    custom_package = "com.example.android.testing.espresso.MultiWindowSample.test",
     instruments = ":MultiWindowSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/MultiWindowSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/MultiWindowSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.MultiWindowSample"
+      package="com.example.android.testing.espresso.MultiWindowSample.test"
       android:versionCode="1"
       android:versionName="1.0">
 

--- a/ui/espresso/RecyclerViewSample/BUILD.bazel
+++ b/ui/espresso/RecyclerViewSample/BUILD.bazel
@@ -26,7 +26,7 @@ android_binary(
 android_library(
     name = "RecyclerViewSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.espresso.RecyclerViewSample",
+    custom_package = "com.example.android.testing.espresso.RecyclerViewSample.test",
     deps = [
         gmaven_artifact("androidx.test.espresso:espresso-contrib:aar:" + espressoVersion),
         ":RecyclerViewSampleLib",
@@ -36,7 +36,7 @@ android_library(
 
 android_binary(
     name = "RecyclerViewSampleTest",
-    custom_package = "com.example.android.testing.espresso.RecyclerViewSample",
+    custom_package = "com.example.android.testing.espresso.RecyclerViewSample.test",
     instruments = ":RecyclerViewSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     manifest_values = {

--- a/ui/espresso/RecyclerViewSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/espresso/RecyclerViewSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.espresso.RecyclerViewSample"
+      package="com.example.android.testing.espresso.RecyclerViewSample.test"
       android:versionCode="1"
       android:versionName="1.0">
 


### PR DESCRIPTION
Gradle tests:

```bash
$ for dir in BasicSample CustomMatcherSample DataAdapterSample IdlingResourceSample IntentsAdvancedSample IntentsBasicSample MultiWindowSample RecyclerViewSample
do 
  pushd ui/espresso/$dir
  ./gradlew connectedAndroidTest
  popd
done

...

$ echo $?
0
```

Bazel tests:

```
$ devbazel test //ui/espresso/... --incompatible_package_name_is_a_function=false 
INFO: Invocation ID: 33790409-cc14-4946-a162-754530b72389
INFO: Build option --cache_test_results has changed, discarding analysis cache.
INFO: Analysed 64 targets (0 packages loaded, 1967 targets configured).
INFO: Found 32 targets and 32 test targets...
INFO: Elapsed time: 0.585s, Critical Path: 0.02s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
//ui/espresso/BasicSample:BasicSampleInstrumentationTest_19_x86 (cached) PASSED in 72.2s
//ui/espresso/BasicSample:BasicSampleInstrumentationTest_21_x86 (cached) PASSED in 50.1s
//ui/espresso/BasicSample:BasicSampleInstrumentationTest_22_x86 (cached) PASSED in 74.5s
//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86 (cached) PASSED in 83.4s
//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_19_x86 (cached) PASSED in 95.2s
//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_21_x86 (cached) PASSED in 101.3s
//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_22_x86 (cached) PASSED in 109.1s
//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86 (cached) PASSED in 119.6s
//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_19_x86 (cached) PASSED in 84.8s
//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_21_x86 (cached) PASSED in 108.9s
//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_22_x86 (cached) PASSED in 96.9s
//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86 (cached) PASSED in 99.1s
//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_19_x86 (cached) PASSED in 70.2s
//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_21_x86 (cached) PASSED in 77.8s
//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_22_x86 (cached) PASSED in 67.8s
//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86 (cached) PASSED in 80.1s
//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_19_x86 (cached) PASSED in 62.7s
//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_21_x86 (cached) PASSED in 28.4s
//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_22_x86 (cached) PASSED in 60.2s
//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86 (cached) PASSED in 77.9s
//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_19_x86 (cached) PASSED in 31.7s
//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_21_x86 (cached) PASSED in 34.4s
//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_22_x86 (cached) PASSED in 34.5s
//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86 (cached) PASSED in 38.1s
//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_19_x86 (cached) PASSED in 77.9s
//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_21_x86 (cached) PASSED in 82.4s
//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_22_x86 (cached) PASSED in 89.6s
//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86 (cached) PASSED in 103.0s
//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_19_x86 (cached) PASSED in 68.4s
//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_21_x86 (cached) PASSED in 77.9s
//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_22_x86 (cached) PASSED in 77.9s
//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86 (cached) PASSED in 81.0s

Executed 0 out of 32 tests: 32 tests pass.
INFO: Build completed successfully, 1 total action
```

Fixes https://github.com/googlesamples/android-testing/issues/224
