### PR TITLE
Fix package names of uiautomator.BasicSample test app and app under test

### DIFF
--- a/ui/uiautomator/BasicSample/BUILD.bazel
+++ b/ui/uiautomator/BasicSample/BUILD.bazel
@@ -22,7 +22,7 @@ android_binary(
 android_library(
     name = "BasicSampleTestLib",
     srcs = glob(["app/src/androidTest/**/*.java"]),
-    custom_package = "com.example.android.testing.uiautomator.BasicSample",
+    custom_package = "com.example.android.testing.uiautomator.BasicSample.test",
     deps = [
         ":BasicSampleLib",
         "//:test_deps",
@@ -32,7 +32,7 @@ android_library(
 
 android_binary(
     name = "BasicSampleTest",
-    custom_package = "com.example.android.testing.uiautomator.BasicSample",
+    custom_package = "com.example.android.testing.uiautomator.BasicSample.test",
     instruments = ":BasicSample",
     manifest = "app/src/androidTest/AndroidManifest.xml",
     deps = [":BasicSampleTestLib"],

--- a/ui/uiautomator/BasicSample/app/src/androidTest/AndroidManifest.xml
+++ b/ui/uiautomator/BasicSample/app/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:tools="http://schemas.android.com/tools"
-      package="com.example.android.testing.uiautomator.BasicSample"
+      package="com.example.android.testing.uiautomator.BasicSample.test"
       android:versionCode="1"
       android:versionName="1.0">
     <uses-sdk android:minSdkVersion="18" android:targetSdkVersion="28" />


### PR DESCRIPTION
Fixes issue that is also fixed in https://github.com/googlesamples/android-testing/pull/225 where the app under test and the test app shares the same package name, but that PR missed out on the UIAutomator test.

Tested:

```
$ cd ui/uiautomator/BasicSample
$ ./gradlew connectedAndroidTest
...

04:10:36 V/InstrumentationResultParser: Time: 22.398
04:10:36 V/InstrumentationResultParser: 
04:10:36 V/InstrumentationResultParser: OK (3 tests)
04:10:36 V/InstrumentationResultParser: 
04:10:36 V/InstrumentationResultParser: 
04:10:36 V/InstrumentationResultParser: INSTRUMENTATION_CODE: -1
04:10:36 V/InstrumentationResultParser: 
04:10:36 I/XmlResultReporter: XML test result file generated at /usr/local/google/home/jingwen/code/android-testing/ui/uiautomator/BasicSample/app/build/outputs/androidTest-results/connected/TEST-emulator-5554 - NMR1-app-.xml. Total tests 3, passed 3, 
04:10:36 V/ddms: execute 'am instrument -w -r   com.example.android.testing.uiautomator.BasicSample.test/androidx.test.runner.AndroidJUnitRunner' on 'emulator-5554' : EOF hit. Read: -1
04:10:36 V/ddms: execute: returning
04:10:36 V/ddms: execute: running pm uninstall com.example.android.testing.uiautomator.BasicSample.test
04:10:36 V/ddms: execute 'pm uninstall com.example.android.testing.uiautomator.BasicSample.test' on 'emulator-5554' : EOF hit. Read: -1
04:10:36 V/ddms: execute: returning
04:10:36 V/ddms: execute: running pm uninstall com.example.android.testing.uiautomator.BasicSample
04:10:37 V/ddms: execute 'pm uninstall com.example.android.testing.uiautomator.BasicSample' on 'emulator-5554' : EOF hit. Read: -1
04:10:37 V/ddms: execute: returning


BUILD SUCCESSFUL in 52s
52 actionable tasks: 52 executed

$ devbazel test ...

INFO: Elapsed time: 71.921s, Critical Path: 71.24s
INFO: 75 processes: 66 linux-sandbox, 9 worker.
INFO: Build completed successfully, 89 total actions
//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_19_x86       PASSED in 56.6s
//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_21_x86       PASSED in 61.7s
//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_22_x86       PASSED in 58.8s
//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86       PASSED in 62.3s
```