### PR TITLE
Move Bazel CI configuration to this repository

### DIFF
--- a/bazelci/buildkite-pipeline.yml
+++ b/bazelci/buildkite-pipeline.yml
@@ -1,0 +1,95 @@
+# https://github.com/googlesamples/android-testing#experimental-bazel-support
+---
+platforms:
+  ubuntu1404:
+    build_targets:
+    - "//ui/..."
+    test_flags:
+    - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
+    - "--flaky_test_attempts=3" # Flakes.
+    - "--spawn_strategy=standalone" # Reduce flakes.
+    test_targets:
+    - "//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
+  ubuntu1604:
+    build_targets:
+    - "//ui/..."
+    test_flags:
+    - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
+    - "--flaky_test_attempts=3" # Flakes.
+    - "--spawn_strategy=standalone" # Reduce flakes.
+    test_targets:
+    - "//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
+  ubuntu1804:
+    build_targets:
+    - "//ui/..."
+    test_flags:
+    - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
+    - "--flaky_test_attempts=3" # Flakes.
+    - "--spawn_strategy=standalone" # Reduce flakes.
+    test_targets:
+    - "//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
+    - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
+  macos:
+    # Testing does not work for macos and windows yet
+    build_targets: # Results of `bazel query 'kind(android_binary, //...)'
+      - "//ui/uiautomator/BasicSample:BasicSampleTest"
+      - "//ui/uiautomator/BasicSample:BasicSample"
+      - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleTest"
+      - "//ui/espresso/RecyclerViewSample:RecyclerViewSample"
+      - "//ui/espresso/MultiWindowSample:MultiWindowSampleTest"
+      - "//ui/espresso/MultiWindowSample:MultiWindowSample"
+      - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleTest"
+      - "//ui/espresso/IntentsBasicSample:IntentsBasicSample"
+      - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleTest"
+      - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSample"
+      - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleTest"
+      - "//ui/espresso/IdlingResourceSample:IdlingResourceSample"
+      - "//ui/espresso/DataAdapterSample:DataAdapterSampleTest"
+      - "//ui/espresso/DataAdapterSample:DataAdapterSample"
+      - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleTest"
+      - "//ui/espresso/CustomMatcherSample:CustomMatcherSample"
+      - "//ui/espresso/BasicSample:BasicSampleTest"
+      - "//ui/espresso/BasicSample:BasicSample"
+  windows:
+    build_targets: # Results of `bazel query 'kind(android_binary, //...)'
+      - "//ui/uiautomator/BasicSample:BasicSampleTest"
+      - "//ui/uiautomator/BasicSample:BasicSample"
+      - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleTest"
+      - "//ui/espresso/RecyclerViewSample:RecyclerViewSample"
+      - "//ui/espresso/MultiWindowSample:MultiWindowSampleTest"
+      - "//ui/espresso/MultiWindowSample:MultiWindowSample"
+      - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleTest"
+      - "//ui/espresso/IntentsBasicSample:IntentsBasicSample"
+      - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleTest"
+      - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSample"
+      - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleTest"
+      - "//ui/espresso/IdlingResourceSample:IdlingResourceSample"
+      - "//ui/espresso/DataAdapterSample:DataAdapterSampleTest"
+      - "//ui/espresso/DataAdapterSample:DataAdapterSample"
+      - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleTest"
+      - "//ui/espresso/CustomMatcherSample:CustomMatcherSample"
+      - "//ui/espresso/BasicSample:BasicSampleTest"
+      - "//ui/espresso/BasicSample:BasicSample"


### PR DESCRIPTION
This configuration is currently hosted in https://github.com/bazelbuild/continuous-integration/blob/master/buildkite/pipelines/android-testing-postsubmit.yml. Now that the pipeline is stable, we can move it out to this repository and make changes here instead.

cc @meteorcloudy