### PR TITLE
Build and test all targets on Linux CI, not just API 23

### DIFF
--- a/bazelci/buildkite-pipeline.yml
+++ b/bazelci/buildkite-pipeline.yml
@@ -3,55 +3,31 @@
 platforms:
   ubuntu1404:
     build_targets:
-    - "//ui/..."
+    - "//..."
     test_flags:
     - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
     - "--flaky_test_attempts=3" # Flakes.
     - "--spawn_strategy=standalone" # Reduce flakes.
     test_targets:
-    - "//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
+    - "//..."
   ubuntu1604:
     build_targets:
-    - "//ui/..."
+    - "//..."
     test_flags:
     - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
     - "--flaky_test_attempts=3" # Flakes.
     - "--spawn_strategy=standalone" # Reduce flakes.
     test_targets:
-    - "//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
+    - "//..."
   ubuntu1804:
     build_targets:
-    - "//ui/..."
+    - "//..."
     test_flags:
     - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
     - "--flaky_test_attempts=3" # Flakes.
     - "--spawn_strategy=standalone" # Reduce flakes.
     test_targets:
-    - "//ui/uiautomator/BasicSample:BasicSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/RecyclerViewSample:RecyclerViewSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/MultiWindowSample:MultiWindowSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IntentsBasicSample:IntentsBasicSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IntentsAdvancedSample:IntentsAdvancedSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/IdlingResourceSample:IdlingResourceSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/DataAdapterSample:DataAdapterSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/CustomMatcherSample:CustomMatcherSampleInstrumentationTest_23_x86"
-    - "//ui/espresso/BasicSample:BasicSampleInstrumentationTest_23_x86"
+    - "//..."
   macos:
     # Testing does not work for macos and windows yet
     build_targets: # Results of `bazel query 'kind(android_binary, //...)'


### PR DESCRIPTION
Dry run of this configuration is successful: https://raw.githubusercontent.com/googlesamples/android-testing/master/bazelci/buildkite-pipeline.yml