### PR TITLE
Bump android/android-test's dependency to use a release

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,15 +13,16 @@ android_sdk_repository(
 #
 # This repository contains the supporting tools to run Android instrumentation tests,
 # like the emulator definitions (android_device) and the device broker/test runner.
-ATS_COMMIT = "10c8fdf6a1c9c48a268e2db19646732c62c1313c"
+ATS_TAG = "androidx-test-1.1.1-alpha01"
 
-ATS_SHA256 = "f427adae66469846e41b16b49062a8e320fed5a426ec7072f9bf5cc064450418"
+ATS_SHA256 = "f7e967cb471bc279fda564084e965868d96e6c608fa27e26cf4330ae29cd603e"
+
 
 http_archive(
     name = "android_test_support",
     sha256 = ATS_SHA256,
-    strip_prefix = "android-test-%s" % ATS_COMMIT,
-    urls = ["https://github.com/android/android-test/archive/%s.tar.gz" % ATS_COMMIT],
+    strip_prefix = "android-test-%s" % ATS_TAG,
+    urls = ["https://github.com/android/android-test/archive/%s.tar.gz" % ATS_TAG],
 )
 
 load("@android_test_support//:repo.bzl", "android_test_repositories")


### PR DESCRIPTION
This allows building with `--incompatible_no_transitive_load=true`