### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/bazelci/buildkite-pipeline.yml
+++ b/bazelci/buildkite-pipeline.yml
@@ -1,15 +1,6 @@
 # https://github.com/googlesamples/android-testing#experimental-bazel-support
 ---
 platforms:
-  ubuntu1404:
-    build_targets:
-    - "//..."
-    test_flags:
-    - "--local_test_jobs=8" # Run at most 8 tests (= emulators) in parallel
-    - "--flaky_test_attempts=3" # Flakes.
-    - "--spawn_strategy=standalone" # Reduce flakes.
-    test_targets:
-    - "//..."
   ubuntu1604:
     build_targets:
     - "//..."


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ