### PR TITLE
Suppress dx spam on guice classes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,7 +71,7 @@ maven_install(
         "androidx.test:rules:" + rulesVersion,
         "androidx.test:runner:" + runnerVersion,
         "androidx.test.uiautomator:uiautomator:" + uiAutomatorVersion,
-        "com.google.inject:guice:4.0",
+        maven.artifact("com.google.inject", "guice", "4.0", neverlink = True),
         "junit:junit:4.12",
         "javax.inject:javax.inject:1",
         "org.hamcrest:java-hamcrest:2.0.0.0",


### PR DESCRIPTION
Make guice neverlink to not dex it. 

dx complains about dexing guice classes:

```
INFO: From Dexing external/maven/_dx/com_google_inject_guice_4_0/guice-4.0.jar_desugared.jar with applicable dexopts []:
warning: Ignoring InnerClasses attribute for an anonymous inner class
(com.google.inject.internal.cglib.core.$AbstractClassGenerator$1) that doesn't come with an
associated EnclosingMethod attribute. This class was probably produced by a
compiler that did not target the modern .class file format. The recommended
solution is to recompile the class from source, using an up-to-date compiler
and without specifying any "-target" type options. The consequence of ignoring
this warning is that reflective operations on this class will incorrectly
indicate that it is *not* an inner class.
```