### PR TITLE
Bump dependency on android-test to address Bazel incompatible changes

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,9 +13,9 @@ android_sdk_repository(
 #
 # This repository contains the supporting tools to run Android instrumentation tests,
 # like the emulator definitions (android_device) and the device broker/test runner.
-ATS_TAG = "androidx-test-1.2.0-beta01"
+ATS_TAG = "2e990782519786bca2f8bf23b2c5933f0d69da8d"
 
-ATS_SHA256 = "a9d50157684920a0d23637bba3d26d3e55017c834ea7ecda01908b8511470373"
+ATS_SHA256 = "de74535cc212a5d9f3e2d24d9a6cf9e1a3734e834563458ad6dd5474dd6aa9c7"
 
 
 http_archive(


### PR DESCRIPTION
Fixes #239 

```
$ bazel build --nobuild -k //... --incompatible_new_actions_api  --incompatible_no_transitive_loads  --incompatible_depset_is_not_iterable --incompatible_disable_deprecated_attr_params
INFO: Analyzed 73 targets (0 packages loaded, 0 targets configured).
INFO: Found 73 targets...
INFO: Elapsed time: 0.229s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```

fyi @laurentlb