### PR TITLE
Remove explicit `@TextLayoutMode` and `@LooperMode`

### DIFF
--- a/ui/espresso/CustomMatcherSample/app/build.gradle
+++ b/ui/espresso/CustomMatcherSample/app/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:" + rootProject.extJUnitVersion;
     androidTestImplementation "androidx.test:runner:" + rootProject.runnerVersion;
     androidTestImplementation "androidx.test.espresso:espresso-core:" + rootProject.espressoVersion;
-    androidTestImplementation "org.robolectric:annotations:" + rootProject.robolectricVersion;
 
     testImplementation "androidx.test:core:" + rootProject.coreVersion;
     testImplementation "androidx.test.ext:junit:" + rootProject.extJUnitVersion;

--- a/ui/espresso/CustomMatcherSample/app/src/sharedTest/java/com/example/android/testing/espresso/CustomMatcherSample/HintMatchersTest.java
+++ b/ui/espresso/CustomMatcherSample/app/src/sharedTest/java/com/example/android/testing/espresso/CustomMatcherSample/HintMatchersTest.java
@@ -36,8 +36,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.LooperMode;
-import org.robolectric.annotation.TextLayoutMode;
 
 /**
  * Tests for {@link MainActivity} showcasing the use of custom matchers (see
@@ -45,10 +43,6 @@ import org.robolectric.annotation.TextLayoutMode;
  */
 @RunWith(AndroidJUnit4.class)
 @LargeTest
-// Configure Robolectric to use the more realistic text layout and threading model.
-// These annotations can be removed once this is default behavior in Robolectric
-@TextLayoutMode(TextLayoutMode.Mode.REALISTIC)
-@LooperMode(LooperMode.Mode.PAUSED)
 public class HintMatchersTest {
 
     private static final String INVALID_STRING_TO_BE_TYPED = "Earl Grey";

--- a/ui/espresso/FragmentScenarioSample/app/build.gradle
+++ b/ui/espresso/FragmentScenarioSample/app/build.gradle
@@ -79,5 +79,4 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:" + rootProject.espressoVersion
     androidTestImplementation "androidx.fragment:fragment-testing:" + rootProject.androidxFragmentVersion
     androidTestImplementation "com.google.truth:truth:" + rootProject.truthVersion
-    androidTestImplementation "org.robolectric:annotations:" + rootProject.robolectricVersion
 }

--- a/ui/espresso/FragmentScenarioSample/app/src/sharedTest/java/com/example/android/testing/espresso/fragmentscenario/SampleDialogFragmentTest.kt
+++ b/ui/espresso/FragmentScenarioSample/app/src/sharedTest/java/com/example/android/testing/espresso/fragmentscenario/SampleDialogFragmentTest.kt
@@ -10,7 +10,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.LooperMode
 
 /**
  * A test using the androidx.test unified API, which can execute on an Android device or locally using Robolectric.

--- a/ui/espresso/FragmentScenarioSample/app/src/sharedTest/java/com/example/android/testing/espresso/fragmentscenario/SampleFragmentTest.kt
+++ b/ui/espresso/FragmentScenarioSample/app/src/sharedTest/java/com/example/android/testing/espresso/fragmentscenario/SampleFragmentTest.kt
@@ -9,7 +9,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.annotation.LooperMode
 
 /**
  * A test using the androidx.test unified API, which can execute on an Android device or locally using Robolectric.

--- a/ui/espresso/IntentsBasicSample/app/build.gradle
+++ b/ui/espresso/IntentsBasicSample/app/build.gradle
@@ -61,7 +61,6 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-intents:" + rootProject.espressoVersion;
     androidTestImplementation "androidx.test.ext:truth:" + rootProject.extTruthVersion;
     androidTestImplementation "androidx.test.ext:junit:" + rootProject.extJUnitVersion;
-    androidTestImplementation "org.robolectric:annotations:" + rootProject.robolectricVersion;
 
     testImplementation "androidx.test:core:" + rootProject.coreVersion;
     testImplementation "androidx.test.ext:junit:" + rootProject.extJUnitVersion;

--- a/ui/espresso/IntentsBasicSample/app/src/sharedTest/java/com/example/android/testing/espresso/IntentsBasicSample/DialerActivityTest.java
+++ b/ui/espresso/IntentsBasicSample/app/src/sharedTest/java/com/example/android/testing/espresso/IntentsBasicSample/DialerActivityTest.java
@@ -35,7 +35,6 @@ import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static androidx.test.ext.truth.content.IntentSubject.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.AllOf.allOf;
-import static org.robolectric.annotation.TextLayoutMode.Mode.REALISTIC;
 
 import android.app.Activity;
 import android.content.Intent;
@@ -52,7 +51,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.annotation.TextLayoutMode;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest


### PR DESCRIPTION
This commit removes explicit `@TextLayoutMode` and `@LooperMode` declarations, since they use the default value.

`LooperMode` is set to `PAUSED` in Robolectric 4.13: https://github.com/robolectric/robolectric/blob/79bc3034b38b94ed8b4317b666edb42f093358cd/robolectric/src/main/java/org/robolectric/plugins/LooperModeConfigurer.java#L17
`TextLayoutMode` is set to `REALISTIC` in Robolectric 4.13: https://github.com/robolectric/robolectric/blob/79bc3034b38b94ed8b4317b666edb42f093358cd/robolectric/src/main/java/org/robolectric/plugins/TextLayoutModeConfigurer.java#L17

**Note:** `TextLayoutMode` has been deprecated in Robolectric 4.16.