### PR TITLE
Add missing projects to `projects.conf`

### DIFF
--- a/projects.conf
+++ b/projects.conf
@@ -1,6 +1,7 @@
 integration/ServiceTestRuleSample
 runner/AndroidJunitRunnerSample
 runner/AndroidTestOrchestratorSample
+runner/AndroidTestOrchestratorWithTestCoverageSample
 ui/espresso/AccessibilitySample
 ui/espresso/BasicSample
 ui/espresso/CustomMatcherSample
@@ -10,10 +11,13 @@ ui/espresso/FragmentScenarioSample
 ui/espresso/IdlingResourceSample
 ui/espresso/IntentsAdvancedSample
 ui/espresso/IntentsBasicSample
-ui/espresso/MultiWindowSample
 ui/espresso/MultiProcessSample
+ui/espresso/MultiWindowSample
 ui/espresso/RecyclerViewSample
 ui/espresso/ScreenshotSample
 ui/espresso/WebBasicSample
 ui/uiautomator/BasicSample
 unit/BasicNativeAndroidTest
+unit/BasicSample
+unit/BasicSample-kotlinApp
+unit/BasicUnitAndroidTest

--- a/runner/AndroidTestOrchestratorWithTestCoverageSample/app/build.gradle
+++ b/runner/AndroidTestOrchestratorWithTestCoverageSample/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.androidtestorchestratorsample"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
 

--- a/runner/AndroidTestOrchestratorWithTestCoverageSample/build.gradle
+++ b/runner/AndroidTestOrchestratorWithTestCoverageSample/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -24,14 +24,14 @@ allprojects {
 }
 
 ext {
-    androidxAnnotationVersion = "1.2.0"
-    guavaVersion = "30.1.1-android"
-    coreVersion = "1.6.0-alpha01"
-    extJUnitVersion = "1.2.0-alpha01"
-    runnerVersion = "1.6.0-alpha03"
-    rulesVersion = "1.6.0-alpha01"
+    androidxAnnotationVersion = "1.5.0"
+    guavaVersion = "31.1-android"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
+    rulesVersion = "1.6.1"
     testServicesVersion = "1.5.0-alpha01"
-    orchestratorVersion = "1.5.0-alpha01"
-    espressoVersion = "3.6.0-alpha01"
+    orchestratorVersion = "1.5.0"
+    espressoVersion = "3.6.1"
     truthVersion = "1.1.3"
 }

--- a/ui/espresso/IntentsAdvancedSample/app/build.gradle
+++ b/ui/espresso/IntentsAdvancedSample/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
     buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.espresso.intents.AdvancedSample"

--- a/unit/BasicSample-kotlinApp/app/build.gradle
+++ b/unit/BasicSample-kotlinApp/app/build.gradle
@@ -5,13 +5,13 @@ apply plugin: "kotlin-android"
 apply plugin: "kotlin-android-extensions"
 
 android {
-    compileSdkVersion 27
+    compileSdk 34
     defaultConfig {
         applicationId "com.example.android.testing.unittesting.BasicSample"
-        minSdkVersion 14
+        minSdkVersion 21
         versionCode 1
         versionName "1.0"
-        targetSdkVersion 27
+        targetSdkVersion 34
     }
 }
 

--- a/unit/BasicSample-kotlinApp/build.gradle
+++ b/unit/BasicSample-kotlinApp/build.gradle
@@ -1,13 +1,14 @@
 buildscript {
     ext {
-        kotlinVersion = "1.3.61"
+        agpVersion = "8.5.0"
+        kotlinVersion = "1.9.22"
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.2"
+        classpath "com.android.tools.build:gradle:$agpVersion"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }

--- a/unit/BasicSample/app/build.gradle
+++ b/unit/BasicSample/app/build.gradle
@@ -17,14 +17,14 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdkVersion 30
+    compileSdk 34
     buildToolsVersion = rootProject.buildToolsVersion
     defaultConfig {
         applicationId "com.example.android.testing.unittesting.BasicSample"
-        minSdkVersion 14
+        minSdkVersion 21
         versionCode 1
         versionName "1.0"
-        targetSdkVersion 30
+        targetSdkVersion 34
     }
     productFlavors {
     }

--- a/unit/BasicSample/build.gradle
+++ b/unit/BasicSample/build.gradle
@@ -16,7 +16,7 @@
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.agpVersion = "7.3.0-alpha07"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()

--- a/unit/BasicUnitAndroidTest/app/build.gradle
+++ b/unit/BasicUnitAndroidTest/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: "com.android.application"
 
 android {
-    compileSdk 33
+    compileSdk 34
     buildToolsVersion = rootProject.buildToolsVersion
 
     defaultConfig {
         applicationId "com.example.android.testing.unittesting.basicunitandroidtest"
-        minSdkVersion 14
-        targetSdkVersion 33
+        minSdkVersion 21
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/unit/BasicUnitAndroidTest/build.gradle
+++ b/unit/BasicUnitAndroidTest/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.agpVersion = "8.1.1"
+    ext.agpVersion = "8.5.0"
     repositories {
         // Insert local test repo here
         google()
@@ -25,10 +25,10 @@ allprojects {
 
 ext {
     buildToolsVersion = "31.0.0"
-    androidxAnnotationVersion = "1.2.0"
-    coreVersion = "1.5.0"
-    extJUnitVersion = "1.1.4"
-    runnerVersion = "1.5.0"
+    androidxAnnotationVersion = "1.5.0"
+    coreVersion = "1.6.1"
+    extJUnitVersion = "1.2.1"
+    runnerVersion = "1.6.1"
     hamcrestVersion = "1.3"
     truthVersion = "1.1.3"
 }


### PR DESCRIPTION
The following projects were missing from the `projects.conf` file, so they were not updated when running `update_versions.sh`:
- `runner/AndroidTestOrchestratorWithTestCoverageSample`
- `unit/BasicSample`
- `unit/BasicSample-kotlinApp`
- `unit/BasicUnitAndroidTest`